### PR TITLE
Add missing core settings (shell, CWD, keepAlive, debug, agents)

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,66 @@
           "type": "string",
           "default": "",
           "description": "Browse URL used to turn Jira keys into clickable external links (e.g. https://your-org.atlassian.net/browse)"
+        },
+        "workTerminal.defaultShell": {
+          "type": "string",
+          "default": "",
+          "description": "Default shell command. Leave empty to use $SHELL (or COMSPEC on Windows)."
+        },
+        "workTerminal.defaultTerminalCwd": {
+          "type": "string",
+          "default": "~",
+          "description": "Default working directory for new terminals. Use ~ for home directory."
+        },
+        "workTerminal.keepSessionsAlive": {
+          "type": "boolean",
+          "default": true,
+          "description": "Keep terminal sessions alive when the panel is closed. When false, terminals are killed on panel dispose."
+        },
+        "workTerminal.exposeDebugApi": {
+          "type": "boolean",
+          "default": false,
+          "description": "Expose a debug API for development and troubleshooting."
+        },
+        "workTerminal.claudeCommand": {
+          "type": "string",
+          "default": "claude",
+          "description": "Command used to launch Claude CLI sessions."
+        },
+        "workTerminal.claudeExtraArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Extra arguments appended to all Claude sessions."
+        },
+        "workTerminal.copilotCommand": {
+          "type": "string",
+          "default": "gh",
+          "description": "Command used to launch Copilot CLI sessions."
+        },
+        "workTerminal.copilotExtraArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Extra arguments appended to all Copilot sessions."
+        },
+        "workTerminal.strandsCommand": {
+          "type": "string",
+          "default": "",
+          "description": "Command used to launch Strands agent sessions."
+        },
+        "workTerminal.strandsExtraArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Extra arguments appended to all Strands sessions."
+        },
+        "workTerminal.additionalAgentContext": {
+          "type": "string",
+          "default": "",
+          "description": "Additional context appended to all agent prompts."
+        },
+        "workTerminal.acceptNoResumeHooks": {
+          "type": "boolean",
+          "default": false,
+          "description": "Accept agent sessions that have no resume hooks configured."
         }
       }
     }

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -220,7 +220,13 @@ export class WorkTerminalPanel {
     }
     this._sessionTrackers.clear();
     this._fileWatcher?.dispose();
-    this._terminalManager.disposeAll();
+
+    const config = vscode.workspace.getConfiguration("workTerminal");
+    const keepAlive = config.get<boolean>("keepSessionsAlive", true);
+    if (!keepAlive) {
+      this._terminalManager.disposeAll();
+    }
+
     this._panel.dispose();
   }
 

--- a/src/terminal/TerminalManager.ts
+++ b/src/terminal/TerminalManager.ts
@@ -96,6 +96,17 @@ export class TerminalManager {
   onAgentStateChanged?: (sessionId: string, state: AgentState) => void;
 
   private getDefaultCwd(): string {
+    const config = vscode.workspace.getConfiguration("workTerminal");
+    const configured = config.get<string>("defaultTerminalCwd", "").trim();
+    if (configured) {
+      if (configured === "~") {
+        return os.homedir();
+      }
+      if (configured.startsWith("~/")) {
+        return path.join(os.homedir(), configured.slice(2));
+      }
+      return configured;
+    }
     const folders = vscode.workspace.workspaceFolders;
     if (folders && folders.length > 0) {
       return folders[0].uri.fsPath;
@@ -104,6 +115,11 @@ export class TerminalManager {
   }
 
   private getDefaultShell(): string {
+    const config = vscode.workspace.getConfiguration("workTerminal");
+    const configured = config.get<string>("defaultShell", "").trim();
+    if (configured) {
+      return configured;
+    }
     const platform = os.platform();
     if (platform === "win32") {
       return process.env.COMSPEC || "cmd.exe";


### PR DESCRIPTION
## Summary

- Declare all 12 missing settings in `package.json` `contributes.configuration`: `defaultShell`, `defaultTerminalCwd`, `keepSessionsAlive`, `exposeDebugApi`, `claudeCommand`, `claudeExtraArgs`, `copilotCommand`, `copilotExtraArgs`, `strandsCommand`, `strandsExtraArgs`, `additionalAgentContext`, `acceptNoResumeHooks`
- Wire `TerminalManager.getDefaultShell()` and `getDefaultCwd()` to read from settings before falling back to environment defaults
- Wire `keepSessionsAlive` so terminals are only killed on panel dispose when the setting is `false`

## Test plan

- [x] All 90 existing tests pass (`npx vitest run`)
- [x] Production build succeeds (`npm run build`)
- [ ] Verify settings appear in VS Code Settings UI under "Work Terminal"
- [ ] Verify `defaultShell` override works when set to a custom shell
- [ ] Verify `defaultTerminalCwd` resolves `~` paths correctly
- [ ] Verify `keepSessionsAlive=false` kills terminals on panel close

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)