### PR TITLE
Add scroll-to-bottom button for terminal panels

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -594,6 +594,32 @@ html, body {
   overflow-y: auto !important;
 }
 
+/* Scroll-to-bottom button */
+.wt-scroll-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 10;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  background: var(--vscode-button-background, rgba(255, 255, 255, 0.15));
+  color: var(--vscode-button-foreground, #fff);
+  opacity: 0.8;
+  transition: opacity 0.15s ease;
+}
+
+.wt-scroll-btn:hover {
+  opacity: 1;
+}
+
 /* =============================================================================
    Placeholder / empty state
    ============================================================================= */

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -198,6 +198,9 @@ export class TerminalPanel {
 
     terminal.open(containerEl);
 
+    // Scroll-to-bottom button
+    this.attachScrollButton(containerEl, terminal);
+
     // Try WebGL renderer, fall back to canvas
     let webglAddon: WebglAddon | null = null;
     try {
@@ -732,6 +735,51 @@ export class TerminalPanel {
     for (const tab of this.tabs) {
       tab.terminal.options.theme = theme;
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Scroll-to-bottom button
+  // -------------------------------------------------------------------------
+
+  private attachScrollButton(containerEl: HTMLElement, terminal: Terminal): void {
+    const btn = document.createElement("button");
+    btn.className = "wt-scroll-btn";
+    btn.setAttribute("aria-label", "Scroll to bottom");
+    btn.textContent = "\u2193";
+    containerEl.appendChild(btn);
+
+    let raf: number | null = null;
+    let lastVisible = false;
+
+    const updateVisibility = () => {
+      raf = null;
+      const buf = terminal.buffer.active;
+      const shouldShow = buf.viewportY < buf.baseY;
+      if (shouldShow === lastVisible) return;
+      lastVisible = shouldShow;
+      btn.style.display = shouldShow ? "flex" : "none";
+    };
+
+    const scheduleUpdate = () => {
+      if (raf !== null) return;
+      raf = requestAnimationFrame(updateVisibility);
+    };
+
+    terminal.onScroll(scheduleUpdate);
+
+    // xterm's onScroll may not fire for trackpad/wheel scrolling,
+    // so also listen on the viewport element's native scroll event.
+    const viewport = containerEl.querySelector(".xterm-viewport");
+    if (viewport) {
+      viewport.addEventListener("scroll", scheduleUpdate, { passive: true });
+    }
+
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      terminal.scrollToBottom();
+      terminal.focus();
+      scheduleUpdate();
+    });
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a floating down-arrow button that appears when a terminal tab is scrolled up from the bottom
- Clicking the button scrolls to bottom and refocuses the terminal
- Each terminal tab gets its own independent button instance
- Uses `requestAnimationFrame` batching and listens to both xterm `onScroll` and native viewport scroll events for reliable detection

## Test plan

- [ ] Open a terminal and produce enough output to scroll (e.g. `ls -la /`)
- [ ] Scroll up - verify the button appears in the bottom-right corner
- [ ] Click the button - verify terminal scrolls to bottom and button disappears
- [ ] Open multiple terminal tabs - verify each has its own independent scroll button
- [ ] Verify button styling matches VS Code theme (light and dark)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)