### PR TITLE
Add macOS keyboard shortcuts for terminal navigation

### DIFF
--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -223,6 +223,9 @@ export class TerminalPanel {
       });
     });
 
+    // macOS keyboard shortcut mappings for terminal navigation
+    this.attachTerminalKeyHandler(terminal, sessionId);
+
     const tab: TerminalTab = {
       sessionId,
       label,
@@ -627,6 +630,49 @@ export class TerminalPanel {
   // -------------------------------------------------------------------------
   // Keyboard handling
   // -------------------------------------------------------------------------
+
+  /**
+   * Attach macOS keyboard shortcut handler to a terminal instance.
+   * Intercepts Option/Cmd shortcuts for word/line navigation and sends
+   * the corresponding escape sequences to the PTY via postMessage.
+   */
+  private attachTerminalKeyHandler(terminal: Terminal, sessionId: string): void {
+    const sendInput = (data: string) => {
+      this.postMessage({ type: "terminalInput", sessionId, data });
+    };
+
+    terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+      if (event.type !== "keydown") return true;
+
+      // Option (Alt) key shortcuts
+      if (event.altKey && !event.metaKey && !event.ctrlKey) {
+        switch (event.key) {
+          case "ArrowLeft":   sendInput("\x1bb");     return false; // word left
+          case "ArrowRight":  sendInput("\x1bf");     return false; // word right
+          case "Backspace":   sendInput("\x1b\x7f");  return false; // delete word backward
+          case "b":           sendInput("\x1bb");     return false; // word backward
+          case "f":           sendInput("\x1bf");     return false; // word forward
+          case "d":           sendInput("\x1bd");     return false; // delete word forward
+        }
+      }
+
+      // Cmd (Meta) key shortcuts
+      if (event.metaKey && !event.altKey && !event.ctrlKey) {
+        switch (event.key) {
+          case "ArrowLeft":   sendInput("\x01");  return false; // line start (Ctrl-A)
+          case "ArrowRight":  sendInput("\x05");  return false; // line end (Ctrl-E)
+        }
+      }
+
+      // Shift+Enter: literal newline (distinct from Enter submit)
+      if (event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey && event.key === "Enter") {
+        sendInput("\n");
+        return false;
+      }
+
+      return true;
+    });
+  }
 
   private handleKeyboard(e: KeyboardEvent): void {
     const isMod = e.metaKey || e.ctrlKey;


### PR DESCRIPTION
## Summary

- Add `attachCustomKeyEventHandler` to each xterm.js terminal instance for macOS keyboard shortcut support
- Map Option+Arrow/Backspace/B/F/D to word-level navigation and editing escape sequences
- Map Cmd+Left/Right to line start/end (Ctrl-A/Ctrl-E)
- Map Shift+Enter to literal newline (distinct from Enter submit)
- Escape sequences sent via the existing `terminalInput` postMessage channel to the extension host PTY

Closes #24

## Test plan

- [ ] Verify Option+ArrowLeft/Right moves cursor by word in shell terminal
- [ ] Verify Option+Backspace deletes word backward
- [ ] Verify Option+B/F/D work as word navigation/deletion
- [ ] Verify Cmd+Left/Right moves cursor to line start/end
- [ ] Verify Shift+Enter inserts a literal newline
- [ ] Verify regular typing and Cmd+F search still work
- [ ] Verify shortcuts work across multiple terminal tabs
- [ ] `npm run build` passes
- [ ] `npx vitest run` passes (180 tests)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>