### PR TITLE
Open task file in editor on selection

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -339,8 +339,7 @@ export class WorkTerminalPanel {
         this._refreshItems();
         break;
       case "itemSelected":
-        // Selection is tracked in webview; extension can react here
-        // (e.g. open terminals for the selected item)
+        this._handleItemSelected(message.id);
         break;
       case "createItem":
         this._handleCreateItem(message.title, message.column);
@@ -467,6 +466,17 @@ export class WorkTerminalPanel {
     if (!this._workItemService) return;
     await this._workItemService.deleteItem(id);
     await this._refreshItems();
+  }
+
+  private async _handleItemSelected(id: string): Promise<void> {
+    if (!this._workItemService) return;
+    const item = this._workItemService.getItemById(id);
+    if (!item?.path) return;
+    const uri = vscode.Uri.file(item.path);
+    await vscode.window.showTextDocument(uri, {
+      viewColumn: vscode.ViewColumn.Beside,
+      preview: true,
+    });
   }
 
   private async _handleMoveItem(id: string, toColumn: string, index: number): Promise<void> {


### PR DESCRIPTION
## Summary
- When a user clicks a task card in the kanban view, the task's markdown file now opens in a VS Code editor tab beside the webview panel
- Uses `preview: true` so subsequent selections replace the same tab rather than opening many tabs
- Wires the existing `itemSelected` message handler to look up the item via `WorkItemService.getItemById` and open the file with `vscode.window.showTextDocument`

Closes #21

## Test plan
- [ ] Click a task card in the kanban view - verify the markdown file opens in an editor tab beside the panel
- [ ] Click a different task card - verify it replaces the previous preview tab
- [ ] Verify `npx vitest run` passes (180 tests)
- [ ] Verify `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)