### PR TITLE
Add session resume plumbing for agent sessions

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -85,6 +85,7 @@ export class WorkTerminalPanel {
           label: closingInfo.label,
           itemId: closingItemId,
           sessionType: closingInfo.sessionType,
+          agentSessionId: closingInfo.agentSessionId,
         }).catch((err) => {
           console.error("[work-terminal] Session close tracking failed:", err);
         });
@@ -552,14 +553,24 @@ export class WorkTerminalPanel {
     if (!entry) {
       return;
     }
-    this._terminalManager.createTerminal({
-      sessionType: entry.sessionType,
-      itemId: entry.itemId,
-      label: entry.label,
-      cwd: entry.cwd,
-      command: entry.command,
-      args: entry.commandArgs,
-    });
+    if (entry.recoveryMode === "resume" && entry.claudeSessionId) {
+      this._terminalManager.createTerminal({
+        sessionType: entry.sessionType,
+        itemId: entry.itemId,
+        label: entry.label,
+        cwd: entry.cwd,
+        resumeSessionId: entry.claudeSessionId,
+      });
+    } else {
+      this._terminalManager.createTerminal({
+        sessionType: entry.sessionType,
+        itemId: entry.itemId,
+        label: entry.label,
+        cwd: entry.cwd,
+        command: entry.command,
+        args: entry.commandArgs,
+      });
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -731,8 +742,7 @@ export class WorkTerminalPanel {
           itemId: entry.itemId,
           label: entry.label,
           cwd: entry.cwd,
-          command: entry.command,
-          args: entry.commandArgs,
+          resumeSessionId: entry.claudeSessionId,
         });
       } else {
         // Relaunch fresh

--- a/src/terminal/AgentLauncher.ts
+++ b/src/terminal/AgentLauncher.ts
@@ -101,12 +101,17 @@ export function buildClaudeArgs(
   },
   sessionId: string,
   prompt?: string,
+  resumeSessionId?: string,
 ): string[] {
   const args: string[] = [];
   if (settings.claudeExtraArgs) {
     args.push(...parseExtraArgs(settings.claudeExtraArgs));
   }
-  args.push("--session-id", sessionId);
+  if (resumeSessionId) {
+    args.push("--resume", resumeSessionId);
+  } else {
+    args.push("--session-id", sessionId);
+  }
   if (prompt) {
     let fullPrompt = prompt;
     if (settings.additionalAgentContext) {
@@ -123,10 +128,14 @@ export function buildClaudeArgs(
 export function buildCopilotArgs(
   settings: { copilotExtraArgs?: string },
   prompt?: string,
+  resumeSessionId?: string,
 ): string[] {
   const args: string[] = [];
   if (settings.copilotExtraArgs) {
     args.push(...parseExtraArgs(settings.copilotExtraArgs));
+  }
+  if (resumeSessionId) {
+    args.push("--resume", resumeSessionId);
   }
   if (prompt) {
     args.push("-i", prompt);
@@ -136,12 +145,15 @@ export function buildCopilotArgs(
 
 /**
  * Build launch command and args for an agent session type.
+ * When `resumeSessionId` is provided, the agent CLI receives `--resume <id>`
+ * instead of a fresh `--session-id`.
  */
 export function buildAgentLaunchArgs(
   sessionType: string,
   settings: Record<string, string | undefined>,
   sessionId: string,
   prompt?: string,
+  resumeSessionId?: string,
 ): { command: string; args: string[] } {
   switch (sessionType) {
     case "claude":
@@ -154,6 +166,7 @@ export function buildAgentLaunchArgs(
         },
         sessionId,
         sessionType === "claude-with-context" ? prompt : undefined,
+        resumeSessionId,
       );
       return { command, args };
     }
@@ -163,6 +176,7 @@ export function buildAgentLaunchArgs(
       const extraArgs = buildCopilotArgs(
         { copilotExtraArgs: settings.copilotExtraArgs },
         sessionType === "copilot-with-context" ? prompt : undefined,
+        resumeSessionId,
       );
       return { command, args: extraArgs };
     }

--- a/src/terminal/TerminalManager.ts
+++ b/src/terminal/TerminalManager.ts
@@ -137,6 +137,8 @@ export class TerminalManager {
 
   /**
    * Create a new terminal session.
+   * When `resumeSessionId` is provided, the agent CLI is launched with
+   * `--resume <id>` to continue a previous session.
    */
   createTerminal(options: {
     sessionType: SessionType;
@@ -146,11 +148,12 @@ export class TerminalManager {
     command?: string;
     args?: string[];
     contextPrompt?: string;
+    resumeSessionId?: string;
     cols?: number;
     rows?: number;
   }): string {
     const sessionId = generateSessionId();
-    const agentSessionId = generateSessionId();
+    const agentSessionId = options.resumeSessionId || generateSessionId();
     const cwd = options.cwd || this.getDefaultCwd();
     const sessionType = options.sessionType;
     const label = options.label || this.getLabelForType(sessionType);
@@ -176,6 +179,7 @@ export class TerminalManager {
         settings,
         agentSessionId,
         options.contextPrompt,
+        options.resumeSessionId,
       );
       command = launch.command;
       args = launch.args;
@@ -353,8 +357,9 @@ export class TerminalManager {
       }
     }
 
-    this.terminals.delete(sessionId);
+    // Fire onClosed before deleting so listeners can still query session info
     this.onClosed?.(sessionId);
+    this.terminals.delete(sessionId);
   }
 
   /**
@@ -386,10 +391,10 @@ export class TerminalManager {
   /**
    * Get session info for building session state messages.
    */
-  getSessionInfo(sessionId: string): { label: string; sessionType: SessionType } | undefined {
+  getSessionInfo(sessionId: string): { label: string; sessionType: SessionType; agentSessionId: string } | undefined {
     const instance = this.terminals.get(sessionId);
     if (!instance) return undefined;
-    return { label: instance.label, sessionType: instance.sessionType };
+    return { label: instance.label, sessionType: instance.sessionType, agentSessionId: instance.agentSessionId };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Wire `--resume <sessionId>` flag through `AgentLauncher` -> `TerminalManager` -> `WorkTerminalPanel` so closed agent sessions can be resumed instead of relaunched fresh
- Fix `destroyTerminal` ordering bug: fire `onClosed` callback before deleting terminal from map so listeners can query session info (needed for recently-closed tracking)
- Pass `agentSessionId` through `onTerminalClosed` so the `RecentlyClosedStore` captures it for resume

## Key changes

- **`AgentLauncher.ts`**: `buildClaudeArgs`, `buildCopilotArgs`, and `buildAgentLaunchArgs` accept optional `resumeSessionId`; when set, `--resume <id>` replaces `--session-id`
- **`TerminalManager.ts`**: `createTerminal` accepts `resumeSessionId` option; reuses the resume ID as `agentSessionId` for tracking continuity; `getSessionInfo` now returns `agentSessionId`
- **`WorkTerminalPanel.ts`**: restore flow and reopen-closed-terminal both pass `claudeSessionId` as `resumeSessionId` when `recoveryMode` is `"resume"`

## Test plan

- [x] `npx vitest run` - all 90 tests pass
- [x] `npm run build` - builds cleanly
- [ ] Manual: close a Claude session, use "Restore Recent" to resume it - verify `--resume <id>` appears in spawned command
- [ ] Manual: close a Claude session, use "Restore Recent" to relaunch it - verify fresh `--session-id` is used
- [ ] Manual: use Ctrl+Shift+T (reopen closed terminal) on a resumable session - verify resume path is taken

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)