### PR TITLE
Support absolute and ~-relative paths for taskBasePath

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
         "workTerminal.taskBasePath": {
           "type": "string",
           "default": "2 - Areas/Tasks",
-          "description": "Workspace path containing task folders (priority, todo, active, archive)"
+          "description": "Path containing task folders (priority, todo, active, archive). Supports absolute paths, ~/relative paths, or workspace-relative paths."
         },
         "workTerminal.jiraBaseUrl": {
           "type": "string",

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -171,13 +171,14 @@ export class WorkTerminalPanel {
     const config = vscode.workspace.getConfiguration("workTerminal");
     const basePath = config.get<string>("taskBasePath", "2 - Areas/Tasks");
 
-    // Resolve base path against workspace (only if relative)
+    // Resolve base path: expand ~ first, then check if absolute
+    const expandedBase = expandTilde(basePath);
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    const resolvedBase = path.isAbsolute(basePath)
-      ? basePath
+    const resolvedBase = path.isAbsolute(expandedBase)
+      ? expandedBase
       : workspaceFolder
-        ? path.join(workspaceFolder.uri.fsPath, basePath)
-        : basePath;
+        ? path.join(workspaceFolder.uri.fsPath, expandedBase)
+        : expandedBase;
     console.log("[work-terminal] initServices: resolvedBase =", resolvedBase);
 
     const settings: Record<string, unknown> = {
@@ -313,12 +314,13 @@ export class WorkTerminalPanel {
     const config = vscode.workspace.getConfiguration("workTerminal");
     const basePath = config.get<string>("taskBasePath", "2 - Areas/Tasks");
 
+    const expandedBase = expandTilde(basePath);
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    const resolvedBase = path.isAbsolute(basePath)
-      ? basePath
+    const resolvedBase = path.isAbsolute(expandedBase)
+      ? expandedBase
       : workspaceFolder
-        ? path.join(workspaceFolder.uri.fsPath, basePath)
-        : basePath;
+        ? path.join(workspaceFolder.uri.fsPath, expandedBase)
+        : expandedBase;
 
     const settings: Record<string, unknown> = {
       "adapter.taskBasePath": resolvedBase,


### PR DESCRIPTION
## Summary

- Expand `~` in the configured `taskBasePath` before checking if it is absolute, so paths like `~/working/obsidian/test-vault/Test/2 - Areas/Tasks/` resolve correctly
- Absolute paths (e.g. `/Users/tom/notes/tasks/`) continue to work and skip workspace-relative resolution
- Only workspace-relative resolution is used when the path is explicitly relative
- Updated setting description to document the three supported path formats

## Test plan

- [x] `pnpm test` - all 119 tests pass
- [x] `pnpm build` - builds successfully
- [ ] Manually verify: set `taskBasePath` to `~/some/path` and confirm tasks load from expanded home directory
- [ ] Manually verify: set `taskBasePath` to `/absolute/path` and confirm it works without workspace
- [ ] Manually verify: set `taskBasePath` to `relative/path` and confirm it resolves against workspace folder

Closes #53

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>