### PR TITLE
Show template variables as persistent hint below context prompt

### DIFF
--- a/src/webview/profileManager.ts
+++ b/src/webview/profileManager.ts
@@ -228,8 +228,15 @@ export function renderProfileEditor(profile: AgentProfile | null): string {
       </label>
 
       <label>Context prompt template
-        <textarea name="contextPrompt" placeholder="Placeholders: $title, $state, $filePath, $id">${escapeHtml(p.contextPrompt)}</textarea>
+        <textarea name="contextPrompt" placeholder="Enter context prompt...">${escapeHtml(p.contextPrompt)}</textarea>
       </label>
+      <div class="wt-field-hint">
+        Available variables:
+        <code>$title</code> - work item title,
+        <code>$state</code> - work item state,
+        <code>$filePath</code> - file path,
+        <code>$id</code> - work item ID
+      </div>
 
       <h4>Tab bar button</h4>
 

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1091,6 +1091,22 @@ a.wt-card-source--jira:hover {
   resize: vertical;
 }
 
+.wt-field-hint {
+  margin: 2px 0 10px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--vscode-descriptionForeground);
+  opacity: 0.85;
+}
+
+.wt-field-hint code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  background: var(--vscode-textCodeBlock-background, rgba(128, 128, 128, 0.15));
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
 .wt-profile-editor-buttons {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary

- Moves available template variables (`$title`, `$state`, `$filePath`, `$id`) out of the placeholder text into a persistent `wt-field-hint` div below the context prompt textarea
- Placeholder simplified to generic "Enter context prompt..." so it doesn't need to serve double duty as documentation
- Adds styled CSS for the hint text and inline `<code>` variable names

Closes #49

## Test plan

- [ ] Open profile editor, verify hint text is visible below the context prompt textarea
- [ ] Type in the textarea - confirm hint remains visible (not hidden like the old placeholder)
- [ ] Verify all four variables are listed with descriptions
- [ ] Check styling matches VS Code theme (description foreground color, monospace code blocks)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>