### PR TITLE
Add color preview swatch to profile editor

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1131,6 +1131,42 @@ a.wt-card-source--jira:hover {
   border-radius: 3px;
 }
 
+/* Color input row: text + picker + swatch */
+.wt-color-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wt-color-input-row input[type="text"] {
+  flex: 1;
+}
+
+.wt-color-picker {
+  width: 32px;
+  height: 28px;
+  padding: 2px;
+  border: 1px solid var(--vscode-input-border, rgba(255, 255, 255, 0.1));
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.wt-color-preview-swatch {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  border: 1px solid var(--vscode-input-border, rgba(255, 255, 255, 0.1));
+}
+
+.wt-color-preview-swatch--empty {
+  background: transparent;
+  border-style: dashed;
+}
+
 .wt-profile-editor-buttons {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary

- Adds CSS styles for the color input row layout, native `<input type="color">` picker, and live preview swatch in the profile editor
- The HTML markup and JS event wiring were included in #56 - this PR adds the missing stylesheet rules that make the color picker and swatch display correctly

Note: The profile editor's button color field now shows a native color picker and a colored swatch that updates live as you type or pick a color.

Closes #50

## Test plan

- [x] `pnpm test` - all 681 tests pass
- [x] `pnpm build` - builds successfully
- [ ] Open profile editor, verify color input row shows text field + color picker + swatch
- [ ] Type a hex color (e.g. `#D97757`) and verify swatch and picker update
- [ ] Use the native color picker and verify text input and swatch update
- [ ] Clear the color field and verify swatch shows dashed empty state

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>