### PR TITLE
Remove redundant global agent settings, consolidate into profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the "Work Terminal" extension will be documented in this 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Consolidated agent-specific global settings (claudeCommand, claudeExtraArgs, copilotCommand, copilotExtraArgs, strandsCommand, strandsExtraArgs) into agent profiles
+- AgentProfileManager now uses sensible defaults per agent type instead of reading removed global settings
+- TerminalManager no longer reads agent-specific settings from VS Code config - callers resolve commands via AgentProfileManager
+
+### Removed
+
+- Removed 6 redundant global settings: `claudeCommand`, `claudeExtraArgs`, `copilotCommand`, `copilotExtraArgs`, `strandsCommand`, `strandsExtraArgs`
+- Kept `additionalAgentContext` as a cross-cutting global setting
+
+### Added
+
+- One-time migration in AgentProfileManager.load() that copies non-default values from deprecated global settings into existing agent profiles
+
 ## [0.1.0] - 2026-04-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -196,42 +196,6 @@
           "description": "Expose a debug API for development and troubleshooting.",
           "scope": "window"
         },
-        "workTerminal.claudeCommand": {
-          "type": "string",
-          "default": "claude",
-          "description": "Command used to launch Claude CLI sessions.",
-          "scope": "window"
-        },
-        "workTerminal.claudeExtraArgs": {
-          "type": "string",
-          "default": "",
-          "description": "Extra arguments appended to all Claude sessions.",
-          "scope": "window"
-        },
-        "workTerminal.copilotCommand": {
-          "type": "string",
-          "default": "gh",
-          "description": "Command used to launch Copilot CLI sessions.",
-          "scope": "window"
-        },
-        "workTerminal.copilotExtraArgs": {
-          "type": "string",
-          "default": "",
-          "description": "Extra arguments appended to all Copilot sessions.",
-          "scope": "window"
-        },
-        "workTerminal.strandsCommand": {
-          "type": "string",
-          "default": "",
-          "description": "Command used to launch Strands agent sessions.",
-          "scope": "window"
-        },
-        "workTerminal.strandsExtraArgs": {
-          "type": "string",
-          "default": "",
-          "description": "Extra arguments appended to all Strands sessions.",
-          "scope": "window"
-        },
         "workTerminal.additionalAgentContext": {
           "type": "string",
           "default": "",

--- a/src/agents/AgentProfileManager.ts
+++ b/src/agents/AgentProfileManager.ts
@@ -37,6 +37,8 @@ export class AgentProfileManager {
       await this.save();
     }
 
+    await this.migrateGlobalSettings();
+
     this.loaded = true;
     return this.getProfiles();
   }
@@ -147,16 +149,17 @@ export class AgentProfileManager {
     if (profile.command.trim()) {
       return profile.command.trim();
     }
-    const config = vscode.workspace.getConfiguration("workTerminal");
     switch (profile.agentType) {
       case "claude":
-        return config.get<string>("claudeCommand", "claude");
+        return "claude";
       case "copilot":
-        return config.get<string>("copilotCommand", "gh");
+        return "gh";
       case "strands":
-        return config.get<string>("strandsCommand", "strands");
-      case "shell":
+        return "strands";
+      case "shell": {
+        const config = vscode.workspace.getConfiguration("workTerminal");
         return config.get<string>("defaultShell", process.env.SHELL || "/bin/zsh");
+      }
     }
   }
 
@@ -169,22 +172,7 @@ export class AgentProfileManager {
   }
 
   resolveArguments(profile: AgentProfile): string {
-    const profileArgs = profile.arguments.trim();
-    const config = vscode.workspace.getConfiguration("workTerminal");
-    let globalArgs = "";
-    switch (profile.agentType) {
-      case "claude":
-        globalArgs = config.get<string>("claudeExtraArgs", "");
-        break;
-      case "copilot":
-        globalArgs = config.get<string>("copilotExtraArgs", "");
-        break;
-      case "strands":
-        globalArgs = config.get<string>("strandsExtraArgs", "");
-        break;
-    }
-    const parts = [globalArgs.trim(), profileArgs].filter(Boolean);
-    return parts.join(" ");
+    return profile.arguments.trim();
   }
 
   resolveContextPrompt(profile: AgentProfile): string {
@@ -193,6 +181,84 @@ export class AgentProfileManager {
     }
     const config = vscode.workspace.getConfiguration("workTerminal");
     return config.get<string>("additionalAgentContext", "");
+  }
+
+  // ---------------------------------------------------------------------------
+  // One-time migration from deprecated global settings to profiles
+  // ---------------------------------------------------------------------------
+
+  private static MIGRATED_KEY = "agentProfiles.migratedGlobalSettings";
+
+  private async migrateGlobalSettings(): Promise<void> {
+    if (this.globalState.get<boolean>(AgentProfileManager.MIGRATED_KEY)) {
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration("workTerminal");
+    let migrated = false;
+
+    const claudeCmd = config.get<string>("claudeCommand", "claude");
+    const claudeArgs = config.get<string>("claudeExtraArgs", "");
+    const copilotCmd = config.get<string>("copilotCommand", "gh");
+    const copilotArgs = config.get<string>("copilotExtraArgs", "");
+    const strandsCmd = config.get<string>("strandsCommand", "");
+    const strandsArgs = config.get<string>("strandsExtraArgs", "");
+
+    const hasClaudeOverrides =
+      (claudeCmd && claudeCmd !== "claude") || (claudeArgs && claudeArgs.trim() !== "");
+    const hasCopilotOverrides =
+      (copilotCmd && copilotCmd !== "gh") || (copilotArgs && copilotArgs.trim() !== "");
+    const hasStrandsOverrides =
+      (strandsCmd && strandsCmd.trim() !== "") || (strandsArgs && strandsArgs.trim() !== "");
+
+    if (hasClaudeOverrides) {
+      for (const p of this.profiles) {
+        if (p.agentType === "claude") {
+          if (claudeCmd && claudeCmd !== "claude" && !p.command.trim()) {
+            p.command = claudeCmd;
+          }
+          if (claudeArgs && claudeArgs.trim() && !p.arguments.trim()) {
+            p.arguments = claudeArgs.trim();
+          }
+        }
+      }
+      migrated = true;
+    }
+
+    if (hasCopilotOverrides) {
+      for (const p of this.profiles) {
+        if (p.agentType === "copilot") {
+          if (copilotCmd && copilotCmd !== "gh" && !p.command.trim()) {
+            p.command = copilotCmd;
+          }
+          if (copilotArgs && copilotArgs.trim() && !p.arguments.trim()) {
+            p.arguments = copilotArgs.trim();
+          }
+        }
+      }
+      migrated = true;
+    }
+
+    if (hasStrandsOverrides) {
+      for (const p of this.profiles) {
+        if (p.agentType === "strands") {
+          if (strandsCmd && strandsCmd.trim() && !p.command.trim()) {
+            p.command = strandsCmd.trim();
+          }
+          if (strandsArgs && strandsArgs.trim() && !p.arguments.trim()) {
+            p.arguments = strandsArgs.trim();
+          }
+        }
+      }
+      migrated = true;
+    }
+
+    if (migrated) {
+      await this.save();
+      console.log("[work-terminal] Migrated global agent settings to profiles");
+    }
+
+    await this.globalState.update(AgentProfileManager.MIGRATED_KEY, true);
   }
 
   dispose(): void {

--- a/src/terminal/TerminalManager.ts
+++ b/src/terminal/TerminalManager.ts
@@ -161,18 +161,19 @@ export class TerminalManager {
     let command: string;
     let args: string[];
 
-    if (sessionType === "shell") {
-      command = options.command || this.getDefaultShell();
+    if (options.command) {
+      // Caller already resolved the command (profile-based launch)
+      command = options.command;
+      args = options.args || [];
+    } else if (sessionType === "shell") {
+      command = this.getDefaultShell();
       args = options.args || [];
     } else {
-      // Agent session - build launch args
-      const settings: Record<string, string | undefined> = {};
+      // Agent session - build launch args using defaults
       const config = vscode.workspace.getConfiguration("workTerminal");
-      settings.claudeCommand = config.get<string>("claudeCommand");
-      settings.claudeExtraArgs = config.get<string>("claudeExtraArgs");
-      settings.copilotCommand = config.get<string>("copilotCommand");
-      settings.copilotExtraArgs = config.get<string>("copilotExtraArgs");
-      settings.additionalAgentContext = config.get<string>("additionalAgentContext");
+      const settings: Record<string, string | undefined> = {
+        additionalAgentContext: config.get<string>("additionalAgentContext"),
+      };
 
       const launch = buildAgentLaunchArgs(
         sessionType,


### PR DESCRIPTION
## Summary

- Removes 6 redundant global settings (`claudeCommand`, `claudeExtraArgs`, `copilotCommand`, `copilotExtraArgs`, `strandsCommand`, `strandsExtraArgs`) from `package.json` - agent profiles already handle per-profile binary paths and arguments
- Updates `AgentProfileManager` to use sensible defaults per agent type (claude -> "claude", copilot -> "gh", strands -> "strands") instead of reading removed global settings
- Updates `TerminalManager.createTerminal()` to no longer read agent-specific settings from VS Code config
- Adds one-time migration in `AgentProfileManager.load()` that copies non-default values from deprecated settings into existing profiles
- Keeps `additionalAgentContext` as a cross-cutting global setting that applies to all agents

## Test plan

- [x] `pnpm test` - all 119 tests pass
- [x] `pnpm build` - builds successfully
- [ ] Verify profile-based launches still resolve correct commands
- [ ] Verify migration applies old global settings to profiles on first load
- [ ] Verify new installs get correct defaults without migration

Closes #52

🤖 Generated with [Claude Code](https://claude.ai/code)