### PR TITLE
Add README.md and CLAUDE.md project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# vscode-work-terminal-v2
+
+VS Code extension: work item kanban board with per-item tabbed terminals and adapter-based extensibility.
+
+## Architecture
+
+Three-layer design. Each layer has clear responsibilities and boundaries:
+
+```
+src/
+  core/              # Shared types, interfaces, utilities
+    interfaces.ts    # AdapterBundle, BaseAdapter, WorkItem, all extension point interfaces
+    types.ts         # FileRef (platform-agnostic file reference, replaces Obsidian TFile)
+    utils.ts         # expandTilde, stripAnsi, slugify, getNonce, normalizeDisplayText
+    frontmatter.ts   # YAML frontmatter parse/serialise
+    dataStore.ts     # VS Code globalState wrapper
+    session/types.ts # SessionType, StoredSession, PersistedSession
+    agents/types.ts  # AgentProfile, AgentType, ProfileButton, brand colours
+
+  panels/            # VS Code webview panels (singleton editor panel + sidebar)
+    WorkTerminalPanel.ts  # 2-panel webview (list | terminals), message routing, service init
+    SidebarProvider.ts    # Activity bar sidebar webview provider
+
+  services/          # Extension host services
+    WorkItemService.ts    # Item CRUD, column grouping, custom ordering
+    FileWatcher.ts        # Workspace file system watcher for item changes
+
+  session/           # Session lifecycle
+    SessionManager.ts     # Terminal creation, resume, persistence orchestration
+    SessionStore.ts       # In-memory session state (survives panel hide)
+    SessionPersistence.ts # Disk persistence via globalState (7-day retention)
+    RecentlyClosedStore.ts# Recently-closed stack for reopen
+
+  terminal/          # Terminal process management
+    TerminalManager.ts    # node-pty spawn, I/O routing to webview, resize
+    AgentLauncher.ts      # Agent launch args, session ID generation, PATH augmentation
+    AgentStateDetector.ts # Buffer-based agent state detection (active/idle/waiting)
+
+  agents/            # Agent integration
+    AgentLaunchModal.ts   # Quick-pick modal with profile selection
+    AgentProfileManager.ts# Profile CRUD persisted in globalState
+    AgentSessionTracker.ts# Per-session state tracking and aggregation
+    AgentSessionRename.ts # Detects agent-chosen session names from terminal output
+    AgentContextPrompt.ts # Builds context prompts from adapter + settings
+    ClaudeHookManager.ts  # Hook scripts for Claude session resume tracking
+    HeadlessClaude.ts     # Headless Claude for background enrichment
+
+  webview/           # Browser-side webview code (IIFE bundles)
+    main.ts          # Main panel entry point
+    sidebarMain.ts   # Sidebar entry point
+    listPanel.ts     # Kanban columns, drag-drop, card rendering
+    terminalPanel.ts # Terminal tab bar, xterm.js integration
+    profileManager.ts# Profile editor UI
+    messages.ts      # Typed message protocol (webview <-> extension host)
+
+  adapters/
+    task-agent/      # Task-agent adapter (reference implementation)
+      index.ts       # TaskAgentAdapter extending BaseAdapter
+      types.ts       # TaskFile, TaskState, KanbanColumn, STATE_FOLDER_MAP
+      TaskAgentConfig.ts   # PluginConfig: columns, creation columns, settings schema
+      TaskParser.ts        # File-based parsing, frontmatter extraction, goal normalisation
+      TaskMover.ts         # Frontmatter state updates, file moves, activity logging
+      TaskCard.ts          # Card rendering with source/score/goal/blocker badges
+      TaskFileTemplate.ts  # UUID + YAML frontmatter + slug filename generation
+      TaskPromptBuilder.ts # Context prompt for agent sessions
+      BackgroundEnrich.ts  # Headless Claude enrichment on item creation
+
+  extension.ts       # Entry point: activate/deactivate, command registration
+```
+
+### Extension model
+
+The adapter provides 5 required implementations (parser, mover, card renderer, prompt builder, config) plus optional hooks (item creation, split, session label transform, deletion, custom styles). The framework handles everything else: terminals, agent integration, session persistence, drag-drop, state detection.
+
+To create a custom adapter: extend `BaseAdapter`, implement the abstract methods, change the import in `extension.ts`.
+
+### Key design decisions
+
+- **Agent integration owned by framework, not adapter** - AgentLauncher, AgentStateDetector, AgentSessionRename, and AgentProfileManager are framework code. Adapters only provide a `WorkItemPromptBuilder` for context prompts.
+- **UUID-based keying** - Sessions, custom order, and selection all use frontmatter UUIDs, not file paths. Survives renames without re-keying.
+- **2-panel webview layout** - Editor panel with list (kanban) on the left and terminals on the right. Communication is via typed message passing (`WebviewMessage` / `ExtensionMessage`), not direct DOM access.
+- **CSS prefix `wt-`** - All extension CSS classes use the `wt-` prefix. No CSS modules.
+- **Three esbuild bundles** - Extension host (CJS/Node), main webview (IIFE/browser), sidebar webview (IIFE/browser). Static CSS assets copied to `dist/` during build.
+- **node-pty for terminals** - Real PTY sessions via node-pty. Falls back to child_process if node-pty is unavailable.
+- **globalState for persistence** - Session metadata, agent profiles, and custom order stored in VS Code's globalState (survives restarts). No external files.
+
+## Development workflow
+
+- **Build**: `pnpm build` (production, minified) or `pnpm run watch` (incremental rebuilds)
+- **Test**: `pnpm test` (vitest - 8 test files covering utils, frontmatter, state detection, parser, mover, template, prompt builder, card renderer)
+- **Lint**: `pnpm run lint` (ESLint)
+- **Package**: `pnpm run package` (VSIX via vsce)
+- **Debug**: Press F5 in VS Code to launch an Extension Development Host with the extension loaded
+
+### Build output
+
+esbuild produces three bundles in `dist/`:
+- `extension.js` - Extension host (Node.js, CJS). Externals: `vscode`, `node-pty`.
+- `webview.js` - Main panel webview (browser, IIFE).
+- `sidebar.js` - Sidebar webview (browser, IIFE).
+
+## Known constraints
+
+- **node-pty** - Required for real PTY terminal sessions. Native module that needs rebuild per platform/Electron version.
+- **xterm.js CSS** - Full CSS embedded inline via the webview HTML since webviews cannot load node_modules CSS directly.
+- **Tilde expansion** - Always expand `~` via `os.homedir()` before passing paths to spawn or file operations.
+- **Webview isolation** - Webviews run in an iframe sandbox. All communication with the extension host is via `postMessage`. No shared memory, no direct DOM access from extension code.
+- **State detection reads terminal output, not stdout** - Immune to status line redraws. Checks recent lines from the raw output buffer.
+- **Session persistence** - Two tiers: in-memory SessionStore (survives panel hide/show), disk persistence via globalState (7-day retention, UUID-based resume). Copilot resume uses native `--resume`; Claude uses hook-based session ID tracking.
+
+## Development rules
+
+### Commits
+Commit each discrete change individually with a clear message. Do not batch unrelated changes.
+
+### Issue tracking
+Use GitHub Issues as the project TODO list (`gh issue list`, `gh issue create`, `gh issue close`).
+- Log new TODOs, feature requests, and bugs as GitHub issues.
+- When starting work on something, find or create the matching issue and reference it in commits.
+- Use `Closes #N` or `Fixes #N` in commit messages to auto-close issues on push.
+- After committing, push to origin so issue references take effect.
+
+### Testing
+Run `pnpm test` after changes to verify nothing is broken. Build with `pnpm build` to catch type/bundle errors.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,136 @@
 # Work Terminal
 
-A VS Code extension that combines a kanban board for managing work items with per-item tabbed terminals and AI agent integration.
+A VS Code extension that combines a kanban board with per-item tabbed terminals and AI agent integration. Manage work items visually while launching shell sessions, Claude Code, GitHub Copilot, and AWS Strands agents - all from a single panel.
 
 ## Features
 
-### Kanban Board
-Visual kanban board for organising work items with collapsible columns, drag-and-drop reordering, and filtering. Work items are backed by markdown files with YAML frontmatter, so they stay in your project and work with version control.
+- **Kanban board** - Collapsible columns (Priority, Active, To Do, Done) with drag-and-drop reordering and filtering. Work items are markdown files with YAML frontmatter, so they version-control naturally.
+- **Tabbed terminals** - Each work item owns a set of tabbed terminal sessions powered by xterm.js. Switch items and pick up where you left off.
+- **AI agent integration** - Launch Claude Code, GitHub Copilot, or Strands agent sessions directly from work items. Context-aware mode injects item metadata into the agent prompt automatically.
+- **Agent state detection** - Real-time detection of agent state (active, idle, waiting for input) by reading terminal buffer content. Status badges update live on cards and tabs.
+- **Session persistence** - Terminal sessions survive VS Code restarts. Resumable agent sessions (Claude, Copilot) can be recovered with their original session IDs.
+- **Agent profiles** - Reusable launch configurations with custom commands, arguments, working directories, context prompts, and tab-bar button styling (icons, colours, border styles).
+- **Sidebar view** - Compact list of work items with search/filter, accessible from the activity bar.
+- **Guided tour** - Built-in walkthrough to get started quickly.
 
-### Tabbed Terminals
-Each work item gets its own set of tabbed terminals - shell, Claude Code, and GitHub Copilot sessions - all powered by xterm.js. Switch between items and pick up exactly where you left off.
+## Installation
 
-### AI Agent Integration
-First-class support for AI coding agents. Launch Claude Code or Copilot sessions directly from work items, with automatic agent state detection so you can see at a glance which agents are active, idle, or waiting for input.
+### From VSIX
 
-### Session Persistence
-Terminal sessions survive VS Code restarts. Reopen closed terminals and recover agent sessions without losing context.
+```sh
+code --install-extension work-terminal-0.1.0.vsix
+```
 
-### Agent Profile Management
-Create and manage reusable agent profiles to configure how AI agents are launched for different types of work.
+### From source
 
-## Requirements
+```sh
+git clone https://github.com/tomcorke/vscode-work-terminal-v2.git
+cd vscode-work-terminal-v2
+pnpm install
+pnpm build
+# Press F5 in VS Code to launch an Extension Development Host
+```
 
-- VS Code 1.85 or later
-- Python 3 (required by node-pty for terminal emulation)
-- **Optional:** [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) for Claude agent terminals
-- **Optional:** [GitHub Copilot](https://github.com/features/copilot) extension for Copilot agent terminals
+## Development
 
-## Extension Settings
+### Commands
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `workTerminal.taskBasePath` | `2 - Areas/Tasks` | Path containing task folders |
+| Command | Description |
+|---------|-------------|
+| `pnpm install` | Install dependencies |
+| `pnpm build` | Production build (esbuild, minified) |
+| `pnpm run watch` | Watch mode with incremental rebuilds |
+| `pnpm test` | Run tests (vitest) |
+| `pnpm run lint` | Lint with ESLint |
+| `pnpm run package` | Package as VSIX |
+
+### Debugging
+
+Press **F5** in VS Code to launch an Extension Development Host with the extension loaded. The `watch` script provides incremental rebuilds during development.
+
+### Build output
+
+esbuild produces three bundles in `dist/`:
+
+- `extension.js` - Extension host (Node.js, CJS)
+- `webview.js` - Main panel webview (browser, IIFE)
+- `sidebar.js` - Sidebar webview (browser, IIFE)
+
+Static assets (`styles.css`, `sidebar.css`) are copied from `src/webview/` to `dist/` during build.
+
+## Architecture
+
+Three-layer design with clear boundaries between core logic, UI panels/services, and domain-specific adapters.
+
+```
+src/
+  core/                  # Shared types, interfaces, utilities
+    interfaces.ts        # AdapterBundle, BaseAdapter, WorkItem, all extension points
+    types.ts             # FileRef (platform-agnostic file reference)
+    utils.ts             # expandTilde, stripAnsi, slugify, getNonce
+    frontmatter.ts       # YAML frontmatter parsing/serialisation
+    dataStore.ts         # VS Code globalState wrapper
+    session/types.ts     # SessionType, StoredSession, PersistedSession
+    agents/types.ts      # AgentProfile, AgentType, ProfileButton
+
+  panels/                # VS Code webview panels
+    WorkTerminalPanel.ts # Singleton 2-panel webview (list + terminals), message routing
+    SidebarProvider.ts   # Activity bar sidebar webview provider
+
+  services/              # Extension host services
+    WorkItemService.ts   # Item CRUD, column grouping, custom ordering
+    FileWatcher.ts       # Workspace file system watcher for item changes
+
+  session/               # Session lifecycle management
+    SessionManager.ts    # Orchestrates terminal creation, resume, persistence
+    SessionStore.ts      # In-memory session state (survives panel hide)
+    SessionPersistence.ts# Disk persistence via globalState (7-day retention)
+    RecentlyClosedStore.ts# Stack of recently closed terminals for reopen
+
+  terminal/              # Terminal process management
+    TerminalManager.ts   # node-pty spawning, I/O routing, resize handling
+    AgentLauncher.ts     # Agent launch argument building, session ID generation
+    AgentStateDetector.ts# Buffer-based agent state detection (active/idle/waiting)
+
+  agents/                # Agent integration
+    AgentLaunchModal.ts  # Quick-pick launch modal with profile selection
+    AgentProfileManager.ts# Profile CRUD with globalState persistence
+    AgentSessionTracker.ts# Tracks agent sessions for state aggregation
+    AgentSessionRename.ts# Detects and applies agent-chosen session names
+    AgentContextPrompt.ts# Builds context prompts from adapter + settings
+    ClaudeHookManager.ts # Claude hook scripts for session resume tracking
+    HeadlessClaude.ts    # Headless Claude for background enrichment
+
+  webview/               # Browser-side webview code
+    main.ts              # Main panel entry point
+    sidebarMain.ts       # Sidebar entry point
+    listPanel.ts         # Kanban column rendering, drag-drop
+    terminalPanel.ts     # Terminal tab bar, xterm.js integration
+    profileManager.ts    # Profile editor UI
+    messages.ts          # Typed message protocol (webview <-> extension)
+    styles.css           # Main panel styles
+    sidebar.css          # Sidebar styles
+
+  adapters/
+    task-agent/          # Task-agent adapter (reference implementation)
+      index.ts           # TaskAgentAdapter extending BaseAdapter
+      types.ts           # TaskFile, TaskState, KanbanColumn, STATE_FOLDER_MAP
+      TaskAgentConfig.ts # PluginConfig: columns, creation columns, settings
+      TaskParser.ts      # File-based parsing with frontmatter, goal normalisation
+      TaskMover.ts       # Frontmatter state updates, file moves, activity logging
+      TaskCard.ts        # Card rendering with source/score/goal/blocker badges
+      TaskFileTemplate.ts# UUID + YAML frontmatter + slug filename generation
+      TaskPromptBuilder.ts# Context prompt builder for agent sessions
+      BackgroundEnrich.ts# Headless Claude enrichment on item creation
+
+  extension.ts           # Entry point: activate/deactivate, command registration
+```
+
+### Extension model
+
+The adapter provides 5 required implementations (parser, mover, card renderer, prompt builder, config) plus optional hooks (item creation, split, session label transform, deletion, styles). The framework handles everything else: terminals, agent integration, session persistence, drag-drop, state detection.
+
+To create a custom adapter: extend `BaseAdapter`, implement the abstract methods, and change the import in `extension.ts`.
 
 ## Keybindings
 
@@ -40,12 +140,14 @@ Create and manage reusable agent profiles to configure how AI agents are launche
 | `Ctrl+Shift+N` | New Work Item (when panel focused) |
 | `` Ctrl+` `` | New Shell Terminal (when panel focused) |
 
-## Known Issues
+## Requirements
 
-This extension is in early development. Expect rough edges and breaking changes.
+- VS Code 1.85+
+- Node.js 20+ (for node-pty)
+- **Optional:** [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) for Claude agent sessions
+- **Optional:** [GitHub Copilot CLI](https://github.com/features/copilot) for Copilot agent sessions
+- **Optional:** AWS Strands agent CLI for Strands sessions
 
-## Release Notes
+## License
 
-### 0.1.0
-
-Initial release with kanban board, tabbed terminals, AI agent integration, session persistence, and profile management.
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Replaces the stub README with comprehensive documentation covering features, installation, development setup, architecture overview, keybindings, and requirements
- Adds CLAUDE.md with build/test commands, full source tree map, extension model, key design decisions, known constraints, and development rules
- Adapted from the Obsidian work-terminal CLAUDE.md reference, updated for VS Code extension specifics (webview message passing, esbuild bundles, node-pty, globalState persistence, F5 debugging)

Closes #60

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm architecture tree matches actual source files
- [ ] Confirm build/test commands work as documented