### PR TITLE
Add agent state animations on badges and cards

### DIFF
--- a/src/webview/listPanel.ts
+++ b/src/webview/listPanel.ts
@@ -402,9 +402,11 @@ export class ListPanel {
     container.appendChild(badge);
 
     // Agent state indicator on the card wrapper
-    if (info.agentState === "active") {
-      const cardEl = container.closest(".wt-card-wrapper");
-      if (cardEl) cardEl.classList.add("wt-agent-active");
+    const cardEl = container.closest(".wt-card-wrapper");
+    if (cardEl) {
+      cardEl.classList.toggle("wt-agent-active", info.agentState === "active");
+      cardEl.classList.toggle("wt-agent-waiting", info.agentState === "waiting");
+      cardEl.classList.toggle("wt-agent-idle", info.agentState === "idle");
     }
   }
 
@@ -428,6 +430,8 @@ export class ListPanel {
 
     const info = this.state.sessionCounts.get(itemId);
     card.classList.toggle("wt-agent-active", info?.agentState === "active");
+    card.classList.toggle("wt-agent-waiting", info?.agentState === "waiting");
+    card.classList.toggle("wt-agent-idle", info?.agentState === "idle");
   }
 
   // ---------------------------------------------------------------------------

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -472,6 +472,8 @@ a.wt-card-source--jira:hover {
    Agent state indicators on cards
    ============================================================================= */
 
+/* --- Active: rotating arc spinner on session badges (3.2s) --- */
+
 .wt-agent-active .wt-session-badge {
   position: relative;
   overflow: visible;
@@ -486,13 +488,35 @@ a.wt-card-source--jira:hover {
   background: conic-gradient(#38a169 0deg, #38a169 90deg, transparent 90deg, transparent 360deg);
   mask: radial-gradient(farthest-side, transparent calc(100% - 2.5px), #000 calc(100% - 2px));
   -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 2.5px), #000 calc(100% - 2px));
-  animation: wt-arc-spin 1.2s linear infinite;
+  animation: wt-spin 3.2s linear infinite;
   z-index: -1;
 }
 
-@keyframes wt-arc-spin {
+@keyframes wt-spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
+}
+
+/* --- Waiting: pulsing glow on the card wrapper (2.5s) --- */
+
+.wt-agent-waiting {
+  animation: wt-waiting-glow 2.5s ease-in-out infinite;
+}
+
+@keyframes wt-waiting-glow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(229, 62, 62, 0);
+  }
+  50% {
+    box-shadow: 0 0 8px 2px rgba(229, 62, 62, 0.35);
+  }
+}
+
+/* --- Idle: badge grayscale filter (applied after delay) --- */
+
+.wt-agent-idle .wt-session-badge {
+  filter: grayscale(0.7);
+  transition: filter 2s ease;
 }
 
 /* =============================================================================
@@ -601,6 +625,34 @@ a.wt-card-source--jira:hover {
 
 .wt-tab-close:hover {
   color: var(--vscode-editor-foreground);
+}
+
+/* Tab agent state dot */
+.wt-tab-state-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.wt-tab-state-dot--active {
+  background-color: #38a169;
+  animation: wt-spin 3.2s linear infinite;
+}
+
+.wt-tab-state-dot--waiting {
+  background-color: #e53e3e;
+  animation: wt-tab-dot-pulse 2.5s ease-in-out infinite;
+}
+
+.wt-tab-state-dot--idle {
+  background-color: #d69e2e;
+  filter: grayscale(0.7);
+}
+
+@keyframes wt-tab-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
 }
 
 .wt-tab-dragging {

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -366,11 +366,7 @@ export class TerminalPanel {
 
       if (tab.sessionType !== "shell" && tab.agentState !== "inactive") {
         const dot = document.createElement("span");
-        dot.style.width = "6px";
-        dot.style.height = "6px";
-        dot.style.borderRadius = "50%";
-        dot.style.backgroundColor = STATE_COLORS[tab.agentState] || "transparent";
-        dot.style.flexShrink = "0";
+        dot.className = `wt-tab-state-dot wt-tab-state-dot--${tab.agentState}`;
         dot.title = tab.agentState;
         tabEl.appendChild(dot);
       }


### PR DESCRIPTION
## Summary

- **Active**: rotating arc spinner (`@keyframes wt-spin`, 3.2s) on session badges in both list panel and tab bar
- **Waiting**: pulsing glow animation (`@keyframes wt-waiting-glow`, 2.5s) on the card wrapper
- **Idle**: grayscale filter applied to session badges
- Tab bar dots now use CSS classes (`wt-tab-state-dot--*`) with matching animations instead of inline styles
- `listPanel.ts` now toggles `wt-agent-waiting` and `wt-agent-idle` classes (previously only `wt-agent-active` was toggled)

Closes #63

## Test plan

- [x] `pnpm test` - 119 tests pass
- [x] `pnpm build` - builds successfully
- [ ] Manual: verify active spinner animation appears on agent badges
- [ ] Manual: verify waiting glow pulses on card wrapper
- [ ] Manual: verify idle badges show grayscale
- [ ] Manual: verify tab bar dots animate per state