### PR TITLE
Use Shift+Enter to confirm tab inline rename

### DIFF
--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -514,7 +514,7 @@ export class TerminalPanel {
 
     input.addEventListener("blur", commit);
     input.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") { e.preventDefault(); input.blur(); }
+      if (e.key === "Enter" && e.shiftKey) { e.preventDefault(); input.blur(); }
       else if (e.key === "Escape") { e.preventDefault(); input.removeEventListener("blur", commit); this.renderTabBar(); }
     });
 


### PR DESCRIPTION
## Summary
- Changes the inline rename confirm key from plain Enter to Shift+Enter, matching Obsidian parity behavior
- Blur still confirms, Escape still cancels

Closes #68

## Test plan
- [ ] Double-click a tab label to enter inline edit mode
- [ ] Verify Shift+Enter confirms the rename
- [ ] Verify plain Enter does not confirm (no-op)
- [ ] Verify blur (clicking away) confirms the rename
- [ ] Verify Escape cancels without renaming
- [ ] Verify context menu Rename still works

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>