### PR TITLE
Add move-to-top button on cards

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -440,6 +440,9 @@ export class WorkTerminalPanel {
       case "contextMenuDelete":
         this._handleDeleteItem(message.itemId);
         break;
+      case "moveToTop":
+        this._handleMoveToTop(message.itemId);
+        break;
       case "requestLaunchModal":
         this.showLaunchModal();
         break;
@@ -519,6 +522,14 @@ export class WorkTerminalPanel {
   private async _handleMoveItem(id: string, toColumn: string, index: number): Promise<void> {
     if (!this._workItemService) return;
     await this._workItemService.moveItem(id, toColumn, index);
+    await this._refreshItems();
+  }
+
+  private async _handleMoveToTop(itemId: string): Promise<void> {
+    if (!this._workItemService) return;
+    const item = this._workItemService.getItemById(itemId);
+    if (!item) return;
+    this._workItemService.updateCustomOrder(itemId, item.state, 0);
     await this._refreshItems();
   }
 

--- a/src/webview/listPanel.ts
+++ b/src/webview/listPanel.ts
@@ -200,9 +200,21 @@ export class ListPanel {
     titleEl.textContent = item.title;
     titleRow.appendChild(titleEl);
 
-    // Actions container (session badge goes here)
+    // Actions container (move-to-top button + session badge)
     const actionsEl = document.createElement("div");
     actionsEl.className = "wt-card-actions";
+
+    // Move-to-top button (visible on card hover via CSS)
+    const moveTopBtn = document.createElement("button");
+    moveTopBtn.className = "wt-move-to-top-btn";
+    moveTopBtn.title = "Move to top";
+    moveTopBtn.textContent = "\u2191";
+    moveTopBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.vscode.postMessage({ type: "moveToTop", itemId: item.id });
+    });
+    actionsEl.appendChild(moveTopBtn);
+
     titleRow.appendChild(actionsEl);
 
     card.appendChild(titleRow);
@@ -338,6 +350,13 @@ export class ListPanel {
         },
       });
     }
+
+    menuItems.push({
+      label: "Move to Top",
+      action: () => {
+        this.vscode.postMessage({ type: "moveToTop", itemId: item.id });
+      },
+    });
 
     menuItems.push({ label: "", action: () => {}, separator: true });
 

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -33,6 +33,7 @@ export type WebviewMessage =
   | { type: "copyToClipboard"; text: string }
   | { type: "contextMenuMove"; itemId: string; toColumn: string }
   | { type: "contextMenuDelete"; itemId: string }
+  | { type: "moveToTop"; itemId: string }
   | { type: "requestLaunchModal" };
 
 // ---- Extension -> Webview ----

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -243,6 +243,30 @@ html, body {
   gap: 6px;
 }
 
+/* Move-to-top button: hidden by default, shown on card hover */
+.wt-move-to-top-btn {
+  display: none;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 2px 4px;
+  opacity: 0.7;
+}
+
+.wt-move-to-top-btn:hover {
+  opacity: 1;
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.wt-card-wrapper:hover .wt-move-to-top-btn {
+  display: inline-flex;
+}
+
 /* Card title */
 .wt-card-title {
   font-weight: 500;


### PR DESCRIPTION
## Summary

- Adds an arrow button in the card actions area (top-right) that appears on hover and moves the item to position 0 in its column
- Adds a "Move to Top" option in the card right-click context menu
- Uses `WorkItemService.updateCustomOrder` to persist the reordered position

Closes #72

## Test plan

- [ ] Hover over a card and verify the up-arrow button appears in the top-right
- [ ] Click the button and verify the card moves to the top of its column
- [ ] Right-click a card and verify "Move to Top" appears in the context menu
- [ ] Click "Move to Top" from context menu and verify it works
- [ ] Verify the reordered position persists after panel reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)