### PR TITLE
Add ingesting/success animations and placeholder cards

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -482,7 +482,27 @@ export class WorkTerminalPanel {
       if (!input) return;
       title = input;
     }
-    const result = await this._workItemService.createItem(title, column);
+
+    // Show placeholder card immediately while file is being created
+    const placeholderId = `__pending_${Date.now()}`;
+    const targetColumn = column || this._adapter!.config.creationColumns[0]?.id || "";
+    this.postMessage({ type: "addPlaceholder", placeholderId, title, column: targetColumn });
+
+    let result: Awaited<ReturnType<typeof this._workItemService.createItem>>;
+    try {
+      result = await this._workItemService.createItem(title, column);
+    } catch {
+      this.postMessage({ type: "failPlaceholder", placeholderId });
+      return;
+    }
+
+    // Resolve placeholder to real card
+    if (result) {
+      this.postMessage({ type: "resolvePlaceholder", placeholderId, realId: result.id });
+    } else {
+      this.postMessage({ type: "failPlaceholder", placeholderId });
+    }
+
     await this._refreshItems();
 
     if (result && result.enrichmentDone) {

--- a/src/webview/listPanel.ts
+++ b/src/webview/listPanel.ts
@@ -14,6 +14,12 @@ interface SessionInfo {
   agentState?: "active" | "idle" | "waiting";
 }
 
+interface PlaceholderCard {
+  id: string;
+  title: string;
+  column: string;
+}
+
 interface ListPanelState {
   items: WorkItemDTO[];
   columns: string[];
@@ -22,6 +28,9 @@ interface ListPanelState {
   filterTerm: string;
   sessionCounts: Map<string, SessionInfo>;
   ingestingIds: Set<string>;
+  placeholders: Map<string, PlaceholderCard>;
+  /** IDs that should play success animation on next render */
+  pendingSuccessIds: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +57,8 @@ export class ListPanel {
       filterTerm: "",
       sessionCounts: new Map(),
       ingestingIds: new Set(),
+      placeholders: new Map(),
+      pendingSuccessIds: new Set(),
     };
   }
 
@@ -96,6 +107,35 @@ export class ListPanel {
     if (card) {
       card.classList.remove("wt-card-is-ingesting");
       card.querySelector(".wt-card-ingesting-badge")?.remove();
+      this.playSuccessAnimation(card);
+    }
+  }
+
+  addPlaceholder(placeholderId: string, title: string, column: string): void {
+    this.state.placeholders.set(placeholderId, { id: placeholderId, title, column });
+    this.render();
+    this.scrollToTop();
+  }
+
+  resolvePlaceholder(placeholderId: string, realId: string): void {
+    this.state.placeholders.delete(placeholderId);
+    // Queue success animation for the real card on next render
+    this.state.pendingSuccessIds.add(realId);
+    this.render();
+  }
+
+  failPlaceholder(placeholderId: string): void {
+    const card = this.findCardByItemId(placeholderId);
+    if (card) {
+      card.classList.remove("wt-card-pending", "wt-card-is-ingesting");
+      card.classList.add("wt-card-error");
+      // Auto-dismiss after the error animation completes (2s)
+      setTimeout(() => {
+        this.state.placeholders.delete(placeholderId);
+        card.remove();
+      }, 2000);
+    } else {
+      this.state.placeholders.delete(placeholderId);
     }
   }
 
@@ -160,6 +200,13 @@ export class ListPanel {
 
       this.setupDropZone(cardsEl, colId);
 
+      // Placeholder cards at the top of their target column
+      for (const ph of this.state.placeholders.values()) {
+        if (ph.column === colId) {
+          cardsEl.appendChild(this.renderPlaceholderCard(ph));
+        }
+      }
+
       for (const item of colItems) {
         const card = this.renderCard(item);
         cardsEl.appendChild(card);
@@ -170,6 +217,15 @@ export class ListPanel {
     }
 
     this.applyFilterVisibility();
+
+    // Play queued success animations
+    if (this.state.pendingSuccessIds.size > 0) {
+      for (const id of this.state.pendingSuccessIds) {
+        const card = this.findCardByItemId(id);
+        if (card) this.playSuccessAnimation(card);
+      }
+      this.state.pendingSuccessIds.clear();
+    }
   }
 
   private renderCard(item: WorkItemDTO): HTMLElement {
@@ -576,6 +632,49 @@ export class ListPanel {
 
   private removeDropIndicators(): void {
     this.listEl.querySelectorAll(".wt-drop-indicator").forEach((el) => el.remove());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Placeholder cards & success animation
+  // ---------------------------------------------------------------------------
+
+  private renderPlaceholderCard(ph: PlaceholderCard): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "wt-card-wrapper wt-card-pending wt-card-is-ingesting";
+    card.dataset.itemId = ph.id;
+
+    const titleRow = document.createElement("div");
+    titleRow.className = "wt-card-title-row";
+
+    const titleEl = document.createElement("div");
+    titleEl.className = "wt-card-title";
+    titleEl.textContent = ph.title || "Creating...";
+    titleRow.appendChild(titleEl);
+
+    card.appendChild(titleRow);
+
+    const metaRow = document.createElement("div");
+    metaRow.className = "wt-card-meta";
+
+    const badge = document.createElement("span");
+    badge.className = "wt-card-ingesting-badge";
+    badge.textContent = "creating\u2026";
+    metaRow.appendChild(badge);
+
+    card.appendChild(metaRow);
+
+    return card;
+  }
+
+  private playSuccessAnimation(card: HTMLElement): void {
+    card.classList.add("wt-card-success");
+    card.addEventListener("animationend", () => {
+      card.classList.remove("wt-card-success");
+    }, { once: true });
+  }
+
+  private scrollToTop(): void {
+    this.listEl.scrollTo({ top: 0, behavior: "smooth" });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -71,6 +71,15 @@ window.addEventListener("message", (event: MessageEvent<ExtensionMessage>) => {
     case "clearIngesting":
       listPanel?.clearIngesting(message.itemId);
       break;
+    case "addPlaceholder":
+      listPanel?.addPlaceholder(message.placeholderId, message.title, message.column);
+      break;
+    case "resolvePlaceholder":
+      listPanel?.resolvePlaceholder(message.placeholderId, message.realId);
+      break;
+    case "failPlaceholder":
+      listPanel?.failPlaceholder(message.placeholderId);
+      break;
     case "buttonProfiles":
       terminalPanel?.updateButtonProfiles(message.profiles);
       break;

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -87,4 +87,7 @@ export type ExtensionMessage =
   | { type: "selectItem"; itemId: string }
   | { type: "setIngesting"; itemId: string }
   | { type: "clearIngesting"; itemId: string }
+  | { type: "addPlaceholder"; placeholderId: string; title: string; column: string }
+  | { type: "resolvePlaceholder"; placeholderId: string; realId: string }
+  | { type: "failPlaceholder"; placeholderId: string }
   | { type: "buttonProfiles"; profiles: ButtonProfileInfo[] };

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -330,6 +330,32 @@ html, body {
 /* Ingesting indicator */
 .wt-card-is-ingesting {
   border-left: 2px solid var(--vscode-progressBar-background, #0078d4);
+  overflow: hidden;
+}
+
+/* Shine sweep overlay during ingesting */
+.wt-card-is-ingesting::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    120deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.06) 45%,
+    rgba(255, 255, 255, 0.12) 50%,
+    rgba(255, 255, 255, 0.06) 55%,
+    transparent 70%
+  );
+  animation: wt-card-shine 2s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes wt-card-shine {
+  0% { left: -100%; }
+  100% { left: 100%; }
 }
 
 .wt-card-ingesting-badge {
@@ -340,12 +366,72 @@ html, body {
   padding: 1px 5px;
   font-size: 10px;
   white-space: nowrap;
-  animation: wt-pulse 1.5s ease-in-out infinite;
+  animation: wt-ingesting-pulse 1.5s ease-in-out infinite;
 }
 
-@keyframes wt-pulse {
+@keyframes wt-ingesting-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
+}
+
+/* ---------------------------------------------------------------------------
+   Success animation: green border fade + rising bar
+   --------------------------------------------------------------------------- */
+
+.wt-card-success {
+  animation: wt-success-border-fade 4s ease-out forwards;
+}
+
+@keyframes wt-success-border-fade {
+  0% { border-left-color: #38a169; border-left-width: 3px; }
+  20% { border-left-color: #38a169; border-left-width: 3px; }
+  100% { border-left-color: var(--wt-task-color, transparent); border-left-width: 3px; }
+}
+
+/* Rising bar below card */
+.wt-card-success::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 0;
+  background: rgba(56, 161, 105, 0.12);
+  border-radius: 0 0 4px 4px;
+  animation: wt-success-bar-rise 3.5s ease-out forwards;
+  pointer-events: none;
+}
+
+@keyframes wt-success-bar-rise {
+  0% { height: 0; opacity: 0.8; }
+  30% { height: 100%; opacity: 0.6; }
+  100% { height: 100%; opacity: 0; }
+}
+
+/* ---------------------------------------------------------------------------
+   Placeholder / pending card
+   --------------------------------------------------------------------------- */
+
+.wt-card-pending {
+  opacity: 0.6;
+  border-left-color: var(--vscode-progressBar-background, #0078d4);
+}
+
+.wt-card-pending .wt-card-title {
+  font-style: italic;
+}
+
+/* Error state: red background, fades out */
+.wt-card-error {
+  background: rgba(229, 62, 62, 0.15) !important;
+  border-left-color: #e53e3e !important;
+  animation: wt-error-fade 2s ease-out forwards;
+}
+
+@keyframes wt-error-fade {
+  0% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 /* Goal tag */


### PR DESCRIPTION
## Summary
- Card shine sweep animation during ingestion
- Badge pulse animation for ingesting state
- Success border fade + rising bar on enrichment complete
- Placeholder/pending cards while file is being created
- Error state with auto-fade

Closes #64

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>