### PR TITLE
Full tab context menu: Move to Item, Copy Tab Info, Close All

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -68,8 +68,8 @@ export class WorkTerminalPanel {
     this._terminalManager.onOutput = (sessionId, data) => {
       this.postMessage({ type: "terminalOutput", sessionId, data });
     };
-    this._terminalManager.onCreated = (sessionId, label, sessionType) => {
-      this.postMessage({ type: "terminalCreated", sessionId, label, sessionType });
+    this._terminalManager.onCreated = (sessionId, label, sessionType, itemId) => {
+      this.postMessage({ type: "terminalCreated", sessionId, label, sessionType, itemId: itemId ?? undefined });
       // Notify webview of updated session state for the item
       this._postSessionStateForTerminal(sessionId);
     };
@@ -392,6 +392,12 @@ export class WorkTerminalPanel {
       case "closeTerminal":
         this._terminalManager.destroyTerminal(message.sessionId);
         break;
+      case "closeAllTerminalsForItem":
+        this._handleCloseAllTerminalsForItem(message.itemId);
+        break;
+      case "moveTerminalToItem":
+        this._handleMoveTerminalToItem(message.sessionId, message.toItemId);
+        break;
       case "renameTerminal":
         this._terminalManager.renameTerminal(message.sessionId, message.label);
         break;
@@ -617,6 +623,24 @@ export class WorkTerminalPanel {
         args: entry.commandArgs,
       });
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tab context menu handlers
+  // ---------------------------------------------------------------------------
+
+  private _handleCloseAllTerminalsForItem(itemId: string): void {
+    this._terminalManager.closeAllForItem(itemId);
+  }
+
+  private _handleMoveTerminalToItem(sessionId: string, toItemId: string): void {
+    const oldItemId = this._getItemIdForSession(sessionId);
+    this._terminalManager.reassignTerminal(sessionId, toItemId);
+    // Notify webview of session state changes for both old and new items
+    if (oldItemId) {
+      this._postSessionStateForItem(oldItemId);
+    }
+    this._postSessionStateForItem(toItemId);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/terminal/TerminalManager.ts
+++ b/src/terminal/TerminalManager.ts
@@ -89,7 +89,7 @@ export class TerminalManager {
   /** Callback to send data to the webview. */
   onOutput?: (sessionId: string, data: string) => void;
   /** Callback when a terminal is created. */
-  onCreated?: (sessionId: string, label: string, sessionType: SessionType) => void;
+  onCreated?: (sessionId: string, label: string, sessionType: SessionType, itemId: string | null) => void;
   /** Callback when a terminal exits/closes. */
   onClosed?: (sessionId: string) => void;
   /** Callback when agent state changes. */
@@ -251,7 +251,7 @@ export class TerminalManager {
     }
 
     this.terminals.set(sessionId, instance);
-    this.onCreated?.(sessionId, label, sessionType);
+    this.onCreated?.(sessionId, label, sessionType, instance.itemId);
 
     return sessionId;
   }
@@ -440,6 +440,16 @@ export class TerminalManager {
     const instance = this.terminals.get(sessionId);
     if (instance) {
       instance.label = label;
+    }
+  }
+
+  /**
+   * Reassign a terminal session to a different work item.
+   */
+  reassignTerminal(sessionId: string, toItemId: string): void {
+    const instance = this.terminals.get(sessionId);
+    if (instance) {
+      instance.itemId = toItemId;
     }
   }
 

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -29,12 +29,13 @@ window.addEventListener("message", (event: MessageEvent<ExtensionMessage>) => {
       if (listPanel) {
         listPanel.updateItems(message.items, message.columns);
       }
+      terminalPanel?.updateWorkItems(message.items);
       break;
     case "terminalOutput":
       terminalPanel?.writeOutput(message.sessionId, message.data);
       break;
     case "terminalCreated":
-      terminalPanel?.addTerminal(message.sessionId, message.label, message.sessionType);
+      terminalPanel?.addTerminal(message.sessionId, message.label, message.sessionType, message.itemId);
       break;
     case "terminalClosed":
       terminalPanel?.removeTerminal(message.sessionId);

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -17,6 +17,8 @@ export type WebviewMessage =
   | { type: "terminalResize"; sessionId: string; cols: number; rows: number }
   | { type: "createTerminal"; terminalType: string; itemId?: string }
   | { type: "closeTerminal"; sessionId: string }
+  | { type: "closeAllTerminalsForItem"; itemId: string }
+  | { type: "moveTerminalToItem"; sessionId: string; toItemId: string }
   | { type: "renameTerminal"; sessionId: string; label: string }
   | { type: "filterChanged"; query: string }
   | { type: "dragDrop"; itemId: string; toColumn: string; index: number }
@@ -68,7 +70,7 @@ export interface ButtonProfileInfo {
 export type ExtensionMessage =
   | { type: "updateItems"; items: WorkItemDTO[]; columns: string[] }
   | { type: "terminalOutput"; sessionId: string; data: string }
-  | { type: "terminalCreated"; sessionId: string; label: string; sessionType: string }
+  | { type: "terminalCreated"; sessionId: string; label: string; sessionType: string; itemId?: string }
   | { type: "terminalClosed"; sessionId: string }
   | { type: "agentStateChanged"; sessionId: string; state: string }
   | {

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -12,7 +12,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
-import type { WebviewMessage, TerminalSessionInfo, ButtonProfileInfo } from "./messages";
+import type { WebviewMessage, TerminalSessionInfo, ButtonProfileInfo, WorkItemDTO } from "./messages";
 
 // ---------------------------------------------------------------------------
 // xterm.js CSS (embedded to avoid CSP issues with external stylesheets)
@@ -124,6 +124,7 @@ interface TerminalTab {
   sessionId: string;
   label: string;
   sessionType: string;
+  itemId: string | null;
   terminal: Terminal;
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
@@ -158,6 +159,7 @@ export class TerminalPanel {
   private resizeObserver: ResizeObserver;
   private searchBarVisible = false;
   private buttonProfiles: ButtonProfileInfo[] = [];
+  private workItems: WorkItemDTO[] = [];
 
   constructor(postMessage: (msg: WebviewMessage) => void) {
     this.postMessage = postMessage;
@@ -184,7 +186,7 @@ export class TerminalPanel {
   // Terminal lifecycle
   // -------------------------------------------------------------------------
 
-  addTerminal(sessionId: string, label: string, sessionType: string): void {
+  addTerminal(sessionId: string, label: string, sessionType: string, itemId?: string): void {
     const containerEl = document.createElement("div");
     containerEl.className = "wt-terminal-instance hidden";
     containerEl.dataset.sessionId = sessionId;
@@ -244,7 +246,7 @@ export class TerminalPanel {
     this.attachTerminalKeyHandler(terminal, sessionId);
 
     const tab: TerminalTab = {
-      sessionId, label, sessionType, terminal, fitAddon, searchAddon,
+      sessionId, label, sessionType, itemId: itemId ?? null, terminal, fitAddon, searchAddon,
       containerEl, webglAddon, agentState: "inactive",
     };
 
@@ -414,6 +416,13 @@ export class TerminalPanel {
   // -------------------------------------------------------------------------
 
   /**
+   * Update the cached work items list for context menu features.
+   */
+  updateWorkItems(items: WorkItemDTO[]): void {
+    this.workItems = items;
+  }
+
+  /**
    * Update the spawn button area with profile-driven buttons.
    * Called on init and whenever button profiles change from the extension host.
    */
@@ -558,35 +567,178 @@ export class TerminalPanel {
       `position: fixed; left: ${x}px; top: ${y}px; z-index: 1000; ` +
       "background: var(--vscode-menu-background); color: var(--vscode-menu-foreground); " +
       "border: 1px solid var(--vscode-menu-border, var(--vscode-panel-border)); " +
-      "border-radius: 4px; padding: 4px 0; min-width: 140px; " +
+      "border-radius: 4px; padding: 4px 0; min-width: 160px; " +
       "box-shadow: 0 2px 8px rgba(0,0,0,0.3);";
 
-    const items = [
-      { label: "Rename", action: () => {
-        const labelEl = this.tabsContainerEl.children[index]?.querySelector(".wt-tab-label");
-        if (labelEl) this.startInlineRename(index, labelEl as HTMLElement);
-      }},
-      { label: "Close", action: () => this.postMessage({ type: "closeTerminal", sessionId: tab.sessionId }) },
-      { label: "Close Others", action: () => {
-        for (const t of this.tabs) {
-          if (t.sessionId !== tab.sessionId) this.postMessage({ type: "closeTerminal", sessionId: t.sessionId });
-        }
-      }},
-    ];
+    const menuItemStyle =
+      "padding: 4px 16px; cursor: pointer; font-size: 12px; white-space: nowrap;";
+    const disabledStyle =
+      "padding: 4px 16px; font-size: 12px; white-space: nowrap; opacity: 0.5; cursor: default;";
+    const separatorStyle =
+      "height: 1px; margin: 4px 8px; background: var(--vscode-menu-separatorBackground, var(--vscode-panel-border));";
 
-    for (const item of items) {
-      const itemEl = document.createElement("div");
-      itemEl.textContent = item.label;
-      itemEl.style.cssText = "padding: 4px 16px; cursor: pointer; font-size: 12px; white-space: nowrap;";
-      itemEl.addEventListener("mouseenter", () => { itemEl.style.background = "var(--vscode-menu-selectionBackground)"; itemEl.style.color = "var(--vscode-menu-selectionForeground)"; });
-      itemEl.addEventListener("mouseleave", () => { itemEl.style.background = ""; itemEl.style.color = ""; });
-      itemEl.addEventListener("click", () => { menu.remove(); item.action(); });
-      menu.appendChild(itemEl);
+    const addItem = (label: string, action: (() => void) | null) => {
+      const el = document.createElement("div");
+      el.textContent = label;
+      el.style.cssText = action ? menuItemStyle : disabledStyle;
+      if (action) {
+        el.addEventListener("mouseenter", () => { el.style.background = "var(--vscode-menu-selectionBackground)"; el.style.color = "var(--vscode-menu-selectionForeground)"; });
+        el.addEventListener("mouseleave", () => { el.style.background = ""; el.style.color = ""; });
+        el.addEventListener("click", () => { menu.remove(); action(); });
+      }
+      menu.appendChild(el);
+    };
+
+    const addSeparator = () => {
+      const sep = document.createElement("div");
+      sep.style.cssText = separatorStyle;
+      menu.appendChild(sep);
+    };
+
+    // Rename
+    addItem("Rename", () => {
+      const labelEl = this.tabsContainerEl.children[index]?.querySelector(".wt-tab-label");
+      if (labelEl) this.startInlineRename(index, labelEl as HTMLElement);
+    });
+
+    // Move to Item submenu
+    const otherItems = this.workItems.filter((item) => item.id !== tab.itemId);
+    if (otherItems.length > 0) {
+      const moveEl = document.createElement("div");
+      moveEl.textContent = "Move to Item";
+      moveEl.style.cssText = menuItemStyle + " position: relative;";
+      // Add submenu arrow
+      const arrow = document.createElement("span");
+      arrow.textContent = "\u25B6";
+      arrow.style.cssText = "float: right; margin-left: 12px; font-size: 10px;";
+      moveEl.appendChild(arrow);
+
+      let submenu: HTMLElement | null = null;
+      const showSubmenu = () => {
+        if (submenu) return;
+        submenu = document.createElement("div");
+        submenu.className = "wt-context-menu wt-context-submenu";
+        submenu.style.cssText =
+          "position: fixed; z-index: 1001; " +
+          "background: var(--vscode-menu-background); color: var(--vscode-menu-foreground); " +
+          "border: 1px solid var(--vscode-menu-border, var(--vscode-panel-border)); " +
+          "border-radius: 4px; padding: 4px 0; min-width: 160px; max-height: 300px; overflow-y: auto; " +
+          "box-shadow: 0 2px 8px rgba(0,0,0,0.3);";
+
+        for (const item of otherItems) {
+          const subEl = document.createElement("div");
+          subEl.textContent = item.title;
+          subEl.style.cssText = menuItemStyle;
+          subEl.addEventListener("mouseenter", () => { subEl.style.background = "var(--vscode-menu-selectionBackground)"; subEl.style.color = "var(--vscode-menu-selectionForeground)"; });
+          subEl.addEventListener("mouseleave", () => { subEl.style.background = ""; subEl.style.color = ""; });
+          subEl.addEventListener("click", () => {
+            menu.remove();
+            submenu?.remove();
+            tab.itemId = item.id;
+            this.postMessage({ type: "moveTerminalToItem", sessionId: tab.sessionId, toItemId: item.id });
+          });
+          submenu.appendChild(subEl);
+        }
+
+        document.body.appendChild(submenu);
+
+        // Position submenu to the right of the parent item
+        const rect = moveEl.getBoundingClientRect();
+        const subRect = submenu.getBoundingClientRect();
+        let subLeft = rect.right;
+        let subTop = rect.top;
+        // Flip left if it would overflow the viewport
+        if (subLeft + subRect.width > window.innerWidth) {
+          subLeft = rect.left - subRect.width;
+        }
+        // Adjust top if it would overflow the viewport
+        if (subTop + subRect.height > window.innerHeight) {
+          subTop = Math.max(0, window.innerHeight - subRect.height);
+        }
+        submenu.style.left = `${subLeft}px`;
+        submenu.style.top = `${subTop}px`;
+      };
+
+      const hideSubmenu = () => {
+        if (submenu) { submenu.remove(); submenu = null; }
+      };
+
+      moveEl.addEventListener("mouseenter", () => {
+        moveEl.style.background = "var(--vscode-menu-selectionBackground)";
+        moveEl.style.color = "var(--vscode-menu-selectionForeground)";
+        showSubmenu();
+      });
+      moveEl.addEventListener("mouseleave", (e) => {
+        const related = e.relatedTarget as Node | null;
+        if (submenu && related && submenu.contains(related)) return;
+        moveEl.style.background = "";
+        moveEl.style.color = "";
+        hideSubmenu();
+      });
+
+      menu.appendChild(moveEl);
+    } else {
+      addItem("Move to Item", null);
+    }
+
+    // Copy Tab Info
+    addItem("Copy Tab Info", () => {
+      const itemTitle = tab.itemId
+        ? this.workItems.find((i) => i.id === tab.itemId)?.title ?? "Unknown"
+        : "None";
+      const lines = [
+        `Label: ${tab.label}`,
+        `Type: ${tab.sessionType}`,
+        `Session ID: ${tab.sessionId}`,
+        `Item: ${itemTitle}`,
+      ];
+      this.postMessage({ type: "copyToClipboard", text: lines.join("\n") });
+    });
+
+    addSeparator();
+
+    // Close
+    addItem("Close", () => {
+      this.postMessage({ type: "closeTerminal", sessionId: tab.sessionId });
+    });
+
+    // Close Others
+    addItem("Close Others", () => {
+      for (const t of this.tabs) {
+        if (t.sessionId !== tab.sessionId) {
+          this.postMessage({ type: "closeTerminal", sessionId: t.sessionId });
+        }
+      }
+    });
+
+    // Close All for Item
+    if (tab.itemId) {
+      const itemTitle = this.workItems.find((i) => i.id === tab.itemId)?.title;
+      const closeAllLabel = itemTitle ? `Close All for "${itemTitle}"` : "Close All for Item";
+      addItem(closeAllLabel, () => {
+        this.postMessage({ type: "closeAllTerminalsForItem", itemId: tab.itemId! });
+      });
     }
 
     document.body.appendChild(menu);
+
+    // Adjust menu position if it would overflow the viewport
+    const menuRect = menu.getBoundingClientRect();
+    if (menuRect.right > window.innerWidth) {
+      menu.style.left = `${Math.max(0, window.innerWidth - menuRect.width)}px`;
+    }
+    if (menuRect.bottom > window.innerHeight) {
+      menu.style.top = `${Math.max(0, window.innerHeight - menuRect.height)}px`;
+    }
+
     const dismiss = (e: MouseEvent) => {
-      if (!menu.contains(e.target as Node)) { menu.remove(); document.removeEventListener("mousedown", dismiss); }
+      if (!menu.contains(e.target as Node)) {
+        menu.remove();
+        // Also remove any open submenu
+        const sub = document.querySelector(".wt-context-submenu");
+        if (sub) sub.remove();
+        document.removeEventListener("mousedown", dismiss);
+      }
     };
     requestAnimationFrame(() => { document.addEventListener("mousedown", dismiss); });
   }


### PR DESCRIPTION
## Summary
- Expanded tab context menu with Move to Item submenu, Copy Tab Info, Close All for Item
- New message types for tab context menu features
- Terminal reassignment between work items
- Item ID tracking on terminal tabs

Closes #69

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>