### PR TITLE
Add resume badge on work item cards

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -102,6 +102,8 @@ export class WorkTerminalPanel {
       if (closingItemId) {
         this._postSessionStateForItem(closingItemId);
       }
+      // Update resume badge state after session enters recently-closed store
+      this._postResumeItemIds();
     };
     this._terminalManager.onAgentStateChanged = (sessionId, state) => {
       this.postMessage({ type: "agentStateChanged", sessionId, state });
@@ -341,6 +343,12 @@ export class WorkTerminalPanel {
     this.postMessage({ type: "sessionStateChanged", itemId, sessions });
   }
 
+  private _postResumeItemIds(): void {
+    if (!this._sessionManager) return;
+    const ids = this._sessionManager.getResumableItemIds();
+    this.postMessage({ type: "resumeItemIds", itemIds: [...ids] });
+  }
+
   // ---------------------------------------------------------------------------
   // Button profile sync
   // ---------------------------------------------------------------------------
@@ -429,6 +437,7 @@ export class WorkTerminalPanel {
       case "ready":
         this._refreshItems();
         this._sendButtonProfiles();
+        this._postResumeItemIds();
         break;
       case "itemSelected":
         this._handleItemSelected(message.id);
@@ -525,6 +534,9 @@ export class WorkTerminalPanel {
         break;
       case "requestLaunchModal":
         this.showLaunchModal();
+        break;
+      case "resumeItem":
+        this._handleResumeItem(message.itemId);
         break;
       default:
         break;
@@ -777,6 +789,34 @@ export class WorkTerminalPanel {
         args: entry.commandArgs,
       });
     }
+  }
+
+  private _handleResumeItem(itemId: string): void {
+    if (!this._sessionManager) return;
+    const entry = this._sessionManager.getClosedEntryForItem(itemId);
+    if (!entry) return;
+
+    if (entry.recoveryMode === "resume" && entry.claudeSessionId) {
+      this._terminalManager.createTerminal({
+        sessionType: entry.sessionType,
+        itemId: entry.itemId,
+        label: entry.label,
+        cwd: entry.cwd,
+        resumeSessionId: entry.claudeSessionId,
+      });
+    } else {
+      this._terminalManager.createTerminal({
+        sessionType: entry.sessionType,
+        itemId: entry.itemId,
+        label: entry.label,
+        cwd: entry.cwd,
+        command: entry.command,
+        args: entry.commandArgs,
+      });
+    }
+
+    // After resuming, update the resume badges (entry may still be in store)
+    this._postResumeItemIds();
   }
 
   // ---------------------------------------------------------------------------

--- a/src/session/RecentlyClosedStore.ts
+++ b/src/session/RecentlyClosedStore.ts
@@ -83,6 +83,22 @@ export class RecentlyClosedStore {
     return result;
   }
 
+  /** Get the set of item IDs that have at least one resumable closed session. */
+  getResumableItemIds(): Set<string> {
+    this.prune();
+    const ids = new Set<string>();
+    for (const entry of this.entries) {
+      ids.add(entry.itemId);
+    }
+    return ids;
+  }
+
+  /** Get the most recent closed session for a specific item, or null. */
+  getForItem(itemId: string): ClosedSessionEntry | null {
+    this.prune();
+    return this.entries.find((e) => e.itemId === itemId) ?? null;
+  }
+
   /** Remove expired entries and enforce max size. */
   private prune(): void {
     const cutoff = Date.now() - EXPIRY_MS;

--- a/src/session/SessionManager.ts
+++ b/src/session/SessionManager.ts
@@ -177,6 +177,20 @@ export class SessionManager {
   }
 
   /**
+   * Get the set of item IDs that have resumable closed sessions.
+   */
+  getResumableItemIds(): Set<string> {
+    return this.recentlyClosed.getResumableItemIds();
+  }
+
+  /**
+   * Get the most recent closed session entry for a specific item.
+   */
+  getClosedEntryForItem(itemId: string): ClosedSessionEntry | null {
+    return this.recentlyClosed.getForItem(itemId);
+  }
+
+  /**
    * Get persisted sessions for a specific item.
    */
   async getPersistedSessionsForItem(

--- a/src/webview/listPanel.ts
+++ b/src/webview/listPanel.ts
@@ -31,6 +31,8 @@ interface ListPanelState {
   placeholders: Map<string, PlaceholderCard>;
   /** IDs that should play success animation on next render */
   pendingSuccessIds: Set<string>;
+  /** Item IDs that have resumable closed sessions */
+  resumableItemIds: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -59,6 +61,7 @@ export class ListPanel {
       ingestingIds: new Set(),
       placeholders: new Map(),
       pendingSuccessIds: new Set(),
+      resumableItemIds: new Set(),
     };
   }
 
@@ -90,6 +93,15 @@ export class ListPanel {
       info.agentState = agentState || undefined;
     }
     this.updateAgentIndicator(itemId);
+  }
+
+  updateResumeItemIds(itemIds: string[]): void {
+    const newSet = new Set(itemIds);
+    const allIds = new Set([...this.state.resumableItemIds, ...newSet]);
+    this.state.resumableItemIds = newSet;
+    for (const id of allIds) {
+      this.updateResumeBadge(id);
+    }
   }
 
   setIngesting(itemId: string): void {
@@ -357,6 +369,9 @@ export class ListPanel {
     // Session badge
     this.renderSessionBadge(actionsEl, item.id);
 
+    // Resume badge (shown when item has closed resumable sessions but no active ones)
+    this.renderResumeBadge(actionsEl, item.id);
+
     // Ingesting badge
     if (this.state.ingestingIds.has(item.id)) {
       this.addIngestingBadge(card);
@@ -515,6 +530,41 @@ export class ListPanel {
     card.classList.toggle("wt-agent-active", info?.agentState === "active");
     card.classList.toggle("wt-agent-waiting", info?.agentState === "waiting");
     card.classList.toggle("wt-agent-idle", info?.agentState === "idle");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resume badges
+  // ---------------------------------------------------------------------------
+
+  private renderResumeBadge(container: HTMLElement, itemId: string): void {
+    if (!this.state.resumableItemIds.has(itemId)) return;
+    // Don't show resume badge if the item already has active sessions
+    if (this.state.sessionCounts.has(itemId)) return;
+
+    const badge = document.createElement("span");
+    badge.className = "wt-resume-badge";
+    badge.dataset.resumeBadge = itemId;
+    badge.textContent = "resume";
+    badge.title = "Restore closed session";
+    badge.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.vscode.postMessage({ type: "resumeItem", itemId });
+    });
+    container.appendChild(badge);
+  }
+
+  private updateResumeBadge(itemId: string): void {
+    const card = this.findCardByItemId(itemId);
+    if (!card) return;
+
+    // Remove existing resume badge
+    const existing = card.querySelector(`[data-resume-badge="${CSS.escape(itemId)}"]`);
+    if (existing) existing.remove();
+
+    const actionsEl = card.querySelector(".wt-card-actions");
+    if (actionsEl) {
+      this.renderResumeBadge(actionsEl as HTMLElement, itemId);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -84,6 +84,9 @@ window.addEventListener("message", (event: MessageEvent<ExtensionMessage>) => {
     case "buttonProfiles":
       terminalPanel?.updateButtonProfiles(message.profiles);
       break;
+    case "resumeItemIds":
+      listPanel?.updateResumeItemIds(message.itemIds);
+      break;
     case "focusFilter":
       showFilter();
       break;

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -37,7 +37,8 @@ export type WebviewMessage =
   | { type: "contextMenuDelete"; itemId: string }
   | { type: "doneAndCloseSessions"; itemId: string }
   | { type: "moveToTop"; itemId: string }
-  | { type: "requestLaunchModal" };
+  | { type: "requestLaunchModal" }
+  | { type: "resumeItem"; itemId: string };
 
 // ---- Extension -> Webview ----
 
@@ -95,4 +96,5 @@ export type ExtensionMessage =
   | { type: "addPlaceholder"; placeholderId: string; title: string; column: string }
   | { type: "resolvePlaceholder"; placeholderId: string; realId: string }
   | { type: "failPlaceholder"; placeholderId: string }
-  | { type: "buttonProfiles"; profiles: ButtonProfileInfo[] };
+  | { type: "buttonProfiles"; profiles: ButtonProfileInfo[] }
+  | { type: "resumeItemIds"; itemIds: string[] };

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -351,6 +351,24 @@ html, body {
   cursor: default;
 }
 
+/* Resume badge */
+.wt-resume-badge {
+  display: inline-block;
+  background: rgba(0, 120, 212, 0.15);
+  color: var(--vscode-textLink-foreground, #3794ff);
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.wt-resume-badge:hover {
+  background: rgba(0, 120, 212, 0.3);
+}
+
 /* Ingesting indicator */
 .wt-card-is-ingesting {
   border-left: 2px solid var(--vscode-progressBar-background, #0078d4);


### PR DESCRIPTION
## Summary

- Shows a clickable "resume" badge on work item cards when the item has closed but resumable sessions in `RecentlyClosedStore`
- Badge is hidden when the item already has active sessions, and appears after sessions close
- Clicking the badge triggers the restore flow (resume or relaunch depending on recovery mode)

Closes #73

## Changes

- `RecentlyClosedStore`: added `getResumableItemIds()` and `getForItem()` query methods
- `SessionManager`: exposed `getResumableItemIds()` and `getClosedEntryForItem()` 
- `messages.ts`: added `resumeItemIds` (extension -> webview) and `resumeItem` (webview -> extension) message types
- `listPanel.ts`: added `resumableItemIds` state, `updateResumeItemIds()` public method, resume badge rendering and update logic
- `WorkTerminalPanel.ts`: sends resume item IDs on ready and terminal close, handles `resumeItem` to restore sessions
- `styles.css`: styled `.wt-resume-badge` with link-colored text and hover state

## Test plan

- [x] `pnpm test` - all 119 tests pass
- [x] `pnpm build` - builds successfully
- [ ] Manual: close an agent session, verify resume badge appears on the card
- [ ] Manual: click resume badge, verify session restores
- [ ] Manual: verify badge disappears when a new session is opened for the item

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>