### PR TITLE
Add hook warning banner when Claude hooks are not installed

### DIFF
--- a/src/agents/HookBannerService.ts
+++ b/src/agents/HookBannerService.ts
@@ -1,0 +1,136 @@
+/**
+ * Service that monitors Claude hook installation status and drives a
+ * warning banner in the webview when hooks are not configured.
+ *
+ * Polls ~/.claude/settings.json and ~/.claude/settings.local.json every 10s.
+ * Auto-dismisses when hooks are detected or the user accepts the
+ * acceptNoResumeHooks setting.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const POLL_INTERVAL_MS = 10_000;
+const HOOK_SCRIPT_PATH = path.join(os.homedir(), ".work-terminal", "hooks", "session-change.sh");
+
+export interface HookBannerState {
+  visible: boolean;
+  message: string;
+}
+
+type StateCallback = (state: HookBannerState) => void;
+
+export class HookBannerService {
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _dismissed = false;
+  private _onStateChanged: StateCallback | null = null;
+  private _lastVisible: boolean | null = null;
+  private _acceptNoResumeHooks = false;
+
+  /**
+   * Register a callback that fires when the banner visibility changes.
+   */
+  onStateChanged(cb: StateCallback): void {
+    this._onStateChanged = cb;
+  }
+
+  /**
+   * Start polling hook status. Call once after the webview is ready.
+   */
+  start(acceptNoResumeHooks: boolean): void {
+    this._acceptNoResumeHooks = acceptNoResumeHooks;
+    this._check();
+    this._timer = setInterval(() => this._check(), POLL_INTERVAL_MS);
+  }
+
+  /**
+   * Update the acceptNoResumeHooks setting (called when settings change).
+   */
+  updateAcceptSetting(acceptNoResumeHooks: boolean): void {
+    this._acceptNoResumeHooks = acceptNoResumeHooks;
+    this._check();
+  }
+
+  /**
+   * User dismissed the banner manually.
+   */
+  dismiss(): void {
+    this._dismissed = true;
+    this._emit({ visible: false, message: "" });
+  }
+
+  /**
+   * Stop polling. Call on dispose.
+   */
+  dispose(): void {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+    this._onStateChanged = null;
+  }
+
+  private _check(): void {
+    if (this._dismissed || this._acceptNoResumeHooks) {
+      if (this._lastVisible !== false) {
+        this._emit({ visible: false, message: "" });
+      }
+      return;
+    }
+
+    const hooksFound = this._detectHooks();
+    const visible = !hooksFound;
+
+    if (visible !== this._lastVisible) {
+      this._emit({
+        visible,
+        message: visible
+          ? "Claude resume tracking requires hooks to be installed. Session resume will not work without them."
+          : "",
+      });
+    }
+  }
+
+  private _emit(state: HookBannerState): void {
+    this._lastVisible = state.visible;
+    this._onStateChanged?.(state);
+  }
+
+  /**
+   * Check if the work-terminal hook script exists AND is referenced in
+   * Claude's global settings (~/.claude/settings.json or settings.local.json).
+   */
+  private _detectHooks(): boolean {
+    if (!fs.existsSync(HOOK_SCRIPT_PATH)) {
+      return false;
+    }
+
+    // Check global Claude settings
+    const claudeDir = path.join(os.homedir(), ".claude");
+    for (const filename of ["settings.json", "settings.local.json"]) {
+      const settingsPath = path.join(claudeDir, filename);
+      if (this._settingsContainHook(settingsPath)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private _settingsContainHook(settingsPath: string): boolean {
+    if (!fs.existsSync(settingsPath)) return false;
+    try {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+      const hooks = settings?.hooks;
+      if (!hooks) return false;
+      return !!(
+        hooks.SessionEnd?.length &&
+        hooks.SessionStart?.length &&
+        JSON.stringify(hooks.SessionEnd).includes(HOOK_SCRIPT_PATH) &&
+        JSON.stringify(hooks.SessionStart).includes(HOOK_SCRIPT_PATH)
+      );
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -16,6 +16,8 @@ import { agentTypeToSessionType } from "../core/agents/types";
 import type { AgentProfile } from "../core/agents/types";
 import { showLaunchModal, type LaunchModalResult } from "../agents/AgentLaunchModal";
 import { parseExtraArgs } from "../terminal/AgentLauncher";
+import { HookBannerService } from "../agents/HookBannerService";
+import { installHooks } from "../agents/ClaudeHookManager";
 
 /**
  * Singleton panel that hosts the 2-panel webview layout.
@@ -39,6 +41,7 @@ export class WorkTerminalPanel {
   private _sessionManager: SessionManager | null = null;
   private _profileManager: AgentProfileManager | null = null;
   private readonly _sessionTrackers = new Map<string, AgentSessionTracker>();
+  private readonly _hookBannerService = new HookBannerService();
 
   /** URI of the detail editor tab opened by the extension (null if none). */
   private _detailEditorUri: vscode.Uri | null = null;
@@ -132,6 +135,11 @@ export class WorkTerminalPanel {
           break;
         }
       }
+    });
+
+    // Wire up hook banner service to push state to webview
+    this._hookBannerService.onStateChanged((state) => {
+      this.postMessage({ type: "hookBannerState", visible: state.visible, message: state.message });
     });
   }
 
@@ -294,6 +302,7 @@ export class WorkTerminalPanel {
     this._fileWatcher?.dispose();
     this._renameDisposable?.dispose();
     this._closeDetailEditor();
+    this._hookBannerService.dispose();
 
     const config = vscode.workspace.getConfiguration("workTerminal");
     const keepAlive = config.get<boolean>("keepSessionsAlive", true);
@@ -425,6 +434,10 @@ export class WorkTerminalPanel {
       () => this._refreshItems(),
     );
 
+    this._hookBannerService.updateAcceptSetting(
+      config.get<boolean>("acceptNoResumeHooks", false),
+    );
+
     await this._refreshItems();
   }
 
@@ -434,11 +447,14 @@ export class WorkTerminalPanel {
 
   private _handleMessage(message: WebviewMessage): void {
     switch (message.type) {
-      case "ready":
+      case "ready": {
         this._refreshItems();
         this._sendButtonProfiles();
         this._postResumeItemIds();
+        const cfg = vscode.workspace.getConfiguration("workTerminal");
+        this._hookBannerService.start(cfg.get<boolean>("acceptNoResumeHooks", false));
         break;
+      }
       case "itemSelected":
         this._handleItemSelected(message.id);
         break;
@@ -537,6 +553,12 @@ export class WorkTerminalPanel {
         break;
       case "resumeItem":
         this._handleResumeItem(message.itemId);
+        break;
+      case "installHooks":
+        this._handleInstallHooks();
+        break;
+      case "dismissHookBanner":
+        this._hookBannerService.dismiss();
         break;
       default:
         break;
@@ -1023,6 +1045,24 @@ export class WorkTerminalPanel {
           args: entry.commandArgs,
         });
       }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hook installation
+  // ---------------------------------------------------------------------------
+
+  private async _handleInstallHooks(): Promise<void> {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    const cwd = workspaceFolder?.uri.fsPath ?? require("os").homedir();
+
+    try {
+      await installHooks(cwd);
+      vscode.window.showInformationMessage("Claude hooks installed successfully.");
+    } catch (err) {
+      vscode.window.showErrorMessage(
+        `Failed to install hooks: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -87,6 +87,9 @@ window.addEventListener("message", (event: MessageEvent<ExtensionMessage>) => {
     case "resumeItemIds":
       listPanel?.updateResumeItemIds(message.itemIds);
       break;
+    case "hookBannerState":
+      terminalPanel?.updateHookBanner(message.visible, message.message);
+      break;
     case "focusFilter":
       showFilter();
       break;

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -38,7 +38,9 @@ export type WebviewMessage =
   | { type: "doneAndCloseSessions"; itemId: string }
   | { type: "moveToTop"; itemId: string }
   | { type: "requestLaunchModal" }
-  | { type: "resumeItem"; itemId: string };
+  | { type: "resumeItem"; itemId: string }
+  | { type: "installHooks" }
+  | { type: "dismissHookBanner" };
 
 // ---- Extension -> Webview ----
 
@@ -97,4 +99,5 @@ export type ExtensionMessage =
   | { type: "resolvePlaceholder"; placeholderId: string; realId: string }
   | { type: "failPlaceholder"; placeholderId: string }
   | { type: "buttonProfiles"; profiles: ButtonProfileInfo[] }
-  | { type: "resumeItemIds"; itemIds: string[] };
+  | { type: "resumeItemIds"; itemIds: string[] }
+  | { type: "hookBannerState"; visible: boolean; message: string };

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1467,3 +1467,62 @@ a.wt-card-source--jira:hover {
 .wt-launch-dialog-buttons button.mod-cta:hover {
   background: var(--vscode-button-hoverBackground);
 }
+
+
+/* =============================================================================
+   Hook warning banner
+   ============================================================================= */
+
+.wt-hook-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--vscode-editorWarning-background, rgba(255, 200, 0, 0.1));
+  border-bottom: 1px solid var(--vscode-editorWarning-foreground, #cca700);
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--vscode-editor-foreground);
+}
+
+.wt-hook-banner-icon {
+  color: var(--vscode-editorWarning-foreground, #cca700);
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.wt-hook-banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.wt-hook-banner-btn {
+  padding: 2px 10px;
+  font-size: 11px;
+  border: 1px solid var(--vscode-button-border, var(--vscode-focusBorder));
+  border-radius: 2px;
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.wt-hook-banner-btn:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
+.wt-hook-banner-dismiss {
+  border: none;
+  background: none;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.wt-hook-banner-dismiss:hover {
+  color: var(--vscode-editor-foreground);
+}

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -160,6 +160,7 @@ export class TerminalPanel {
   private searchBarVisible = false;
   private buttonProfiles: ButtonProfileInfo[] = [];
   private workItems: WorkItemDTO[] = [];
+  private hookBannerEl: HTMLElement | null = null;
 
   constructor(postMessage: (msg: WebviewMessage) => void) {
     this.postMessage = postMessage;
@@ -909,11 +910,64 @@ export class TerminalPanel {
   }
 
   // -------------------------------------------------------------------------
+  // Hook warning banner
+  // -------------------------------------------------------------------------
+
+  updateHookBanner(visible: boolean, message: string): void {
+    if (!visible) {
+      if (this.hookBannerEl) {
+        this.hookBannerEl.remove();
+        this.hookBannerEl = null;
+      }
+      return;
+    }
+
+    if (!this.hookBannerEl) {
+      this.hookBannerEl = document.createElement("div");
+      this.hookBannerEl.className = "wt-hook-banner";
+      // Insert before the terminal wrapper
+      this.terminalWrapperEl.parentElement!.insertBefore(
+        this.hookBannerEl,
+        this.terminalWrapperEl,
+      );
+    }
+
+    this.hookBannerEl.innerHTML = "";
+
+    const icon = document.createElement("span");
+    icon.className = "codicon codicon-warning wt-hook-banner-icon";
+    this.hookBannerEl.appendChild(icon);
+
+    const text = document.createElement("span");
+    text.className = "wt-hook-banner-text";
+    text.textContent = message;
+    this.hookBannerEl.appendChild(text);
+
+    const installBtn = document.createElement("button");
+    installBtn.className = "wt-hook-banner-btn";
+    installBtn.textContent = "Install Hooks";
+    installBtn.addEventListener("click", () => {
+      this.postMessage({ type: "installHooks" });
+    });
+    this.hookBannerEl.appendChild(installBtn);
+
+    const dismissBtn = document.createElement("button");
+    dismissBtn.className = "wt-hook-banner-dismiss";
+    dismissBtn.textContent = "\u00d7";
+    dismissBtn.title = "Dismiss";
+    dismissBtn.addEventListener("click", () => {
+      this.postMessage({ type: "dismissHookBanner" });
+    });
+    this.hookBannerEl.appendChild(dismissBtn);
+  }
+
+  // -------------------------------------------------------------------------
   // Cleanup
   // -------------------------------------------------------------------------
 
   dispose(): void {
     this.resizeObserver.disconnect();
+    this.hookBannerEl?.remove();
     for (const tab of this.tabs) {
       tab.webglAddon?.dispose();
       tab.terminal.dispose();


### PR DESCRIPTION
## Summary

- Adds a dismissible warning banner in the webview terminal area when Claude CLI hooks are not detected
- New `HookBannerService` polls `~/.claude/settings.json` and `~/.claude/settings.local.json` every 10s for hook configuration
- Banner includes "Install Hooks" button that triggers hook installation, and a dismiss button
- Auto-dismisses when hooks are detected or `acceptNoResumeHooks` setting is enabled
- Settings changes propagate to the banner service in real-time

Closes #70

## Test plan

- [ ] Verify banner appears when hooks are not installed (remove hook script and settings entries)
- [ ] Verify "Install Hooks" button installs hooks and banner auto-dismisses within 10s
- [ ] Verify dismiss button hides the banner
- [ ] Verify banner does not appear when `acceptNoResumeHooks` is true
- [ ] Verify `pnpm test` passes
- [ ] Verify `pnpm build` succeeds