### PR TITLE
Auto-scroll list to top on new item creation

### DIFF
--- a/src/webview/listPanel.ts
+++ b/src/webview/listPanel.ts
@@ -134,6 +134,7 @@ export class ListPanel {
     // Queue success animation for the real card on next render
     this.state.pendingSuccessIds.add(realId);
     this.render();
+    this.scrollToTop();
   }
 
   failPlaceholder(placeholderId: string): void {


### PR DESCRIPTION
## Summary

- Scroll the list panel to the top when a placeholder card resolves to a real item, so the newly created card is always visible
- The `addPlaceholder` path already scrolled; this adds the same `scrollToTop()` call to `resolvePlaceholder`

Closes #83

## Test plan

- [ ] Create a new work item when the list is scrolled down
- [ ] Verify the list scrolls to the top after the placeholder resolves to a real card
- [ ] Verify `pnpm test` and `pnpm build` pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>