### PR TITLE
Add color-coded section header borders per column

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -170,7 +170,7 @@ html, body {
   color: var(--vscode-descriptionForeground);
   cursor: pointer;
   user-select: none;
-  border-bottom: 1px solid transparent;
+  border-bottom: 2px solid transparent;
 }
 
 .wt-section-header:hover {
@@ -180,7 +180,7 @@ html, body {
 /* Section header colours per state */
 .wt-section-header-priority { border-bottom-color: #e53e3e; }
 .wt-section-header-active { border-bottom-color: var(--vscode-focusBorder); }
-.wt-section-header-todo { border-bottom-color: var(--vscode-descriptionForeground); }
+.wt-section-header-todo { border-bottom-color: #d69e2e; }
 .wt-section-header-done { border-bottom-color: #38a169; }
 
 .wt-collapse-icon {


### PR DESCRIPTION
## Summary
- Increase section header bottom border from 1px to 2px for better visibility
- Change todo column border color from muted gray (`var(--vscode-descriptionForeground)`) to amber (`#d69e2e`)
- Existing colors retained: priority=red (#e53e3e), active=accent (focusBorder), done=green (#38a169)

Closes #84

## Test plan
- [ ] Open the kanban board and verify each column header has a visible colored bottom border
- [ ] Verify priority=red, active=blue/accent, todo=amber, done=green
- [ ] Check appearance in both light and dark VS Code themes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>