### PR TITLE
Add debug API (window.__workTerminalDebug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - One-time migration in AgentProfileManager.load() that copies non-default values from deprecated global settings into existing agent profiles
 - Danger confirmation modal for destructive operations (Delete Item, Done & Close Sessions) using VS Code's native warning dialog
+- Debug API (`window.__workTerminalDebug`) exposed in webview when `workTerminal.exposeDebugApi` setting is enabled, with `getSnapshot()`, `getAllActiveTabs()`, `findTabsByLabel()`, `getActiveSessionIds()`, `getPersistedSessions()`, and `getSessionDiagnostics()` methods for development and troubleshooting (Closes #79)
 
 ## [0.1.0] - 2026-04-01
 

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -438,6 +438,11 @@ export class WorkTerminalPanel {
       config.get<boolean>("acceptNoResumeHooks", false),
     );
 
+    this.postMessage({
+      type: "debugApiState",
+      enabled: config.get<boolean>("exposeDebugApi", false),
+    });
+
     await this._refreshItems();
   }
 
@@ -453,6 +458,9 @@ export class WorkTerminalPanel {
         this._postResumeItemIds();
         const cfg = vscode.workspace.getConfiguration("workTerminal");
         this._hookBannerService.start(cfg.get<boolean>("acceptNoResumeHooks", false));
+        if (cfg.get<boolean>("exposeDebugApi", false)) {
+          this.postMessage({ type: "debugApiState", enabled: true });
+        }
         break;
       }
       case "itemSelected":

--- a/src/webview/debugApi.ts
+++ b/src/webview/debugApi.ts
@@ -1,0 +1,168 @@
+/**
+ * Debug API exposed on window.__workTerminalDebug when the
+ * workTerminal.exposeDebugApi setting is enabled.
+ *
+ * Provides read-only inspection methods for development and troubleshooting.
+ */
+
+import type { ListPanel } from "./listPanel";
+import type { TerminalPanel } from "./terminalPanel";
+
+export interface DebugApi {
+  /** Full snapshot of items, columns, tabs, and session counts. */
+  getSnapshot(): {
+    items: Array<{ id: string; title: string; column: string }>;
+    columns: string[];
+    tabs: Array<{
+      sessionId: string;
+      label: string;
+      sessionType: string;
+      itemId: string | null;
+      agentState: string;
+    }>;
+    activeTabIndex: number;
+    terminalCount: number;
+  };
+
+  /** All active terminal tabs. */
+  getAllActiveTabs(): Array<{
+    sessionId: string;
+    label: string;
+    sessionType: string;
+    itemId: string | null;
+    agentState: string;
+  }>;
+
+  /** Find tabs whose label contains the given string (case-insensitive). */
+  findTabsByLabel(label: string): Array<{
+    sessionId: string;
+    label: string;
+    sessionType: string;
+    itemId: string | null;
+    agentState: string;
+  }>;
+
+  /** Session IDs of all active terminal tabs. */
+  getActiveSessionIds(): string[];
+
+  /** Items with their session counts, optionally filtered by item ID. */
+  getPersistedSessions(itemId?: string): Array<{
+    id: string;
+    title: string;
+    column: string;
+    sessionCount: number;
+    sessionKind: string | undefined;
+    agentState: string | undefined;
+  }>;
+
+  /** Diagnostic summary for troubleshooting. */
+  getSessionDiagnostics(): {
+    totalItems: number;
+    totalTabs: number;
+    activeTabIndex: number;
+    itemsWithSessions: number;
+    agentTabs: number;
+    shellTabs: number;
+    tabsByState: Record<string, number>;
+  };
+}
+
+declare global {
+  interface Window {
+    __workTerminalDebug?: DebugApi;
+  }
+}
+
+/**
+ * Install the debug API on window.__workTerminalDebug.
+ * Requires getter methods on ListPanel (getItems, getColumns, getSessionCounts)
+ * and TerminalPanel (getTabSnapshots, getActiveIndex).
+ */
+export function installDebugApi(
+  listPanel: ListPanel,
+  terminalPanel: TerminalPanel,
+): void {
+  const api: DebugApi = {
+    getSnapshot() {
+      const tabs = terminalPanel.getTabSnapshots();
+      return {
+        items: listPanel.getItems().map((i) => ({
+          id: i.id,
+          title: i.title,
+          column: i.column,
+        })),
+        columns: listPanel.getColumns(),
+        tabs,
+        activeTabIndex: terminalPanel.getActiveIndex(),
+        terminalCount: tabs.length,
+      };
+    },
+
+    getAllActiveTabs() {
+      return terminalPanel.getTabSnapshots();
+    },
+
+    findTabsByLabel(label: string) {
+      const lower = label.toLowerCase();
+      return terminalPanel
+        .getTabSnapshots()
+        .filter((t) => t.label.toLowerCase().includes(lower));
+    },
+
+    getActiveSessionIds() {
+      return terminalPanel.getTabSnapshots().map((t) => t.sessionId);
+    },
+
+    getPersistedSessions(itemId?: string) {
+      const items = listPanel.getItems();
+      const counts = listPanel.getSessionCounts();
+      const filtered = itemId
+        ? items.filter((i) => i.id === itemId)
+        : items;
+      return filtered.map((i) => {
+        const info = counts.get(i.id);
+        return {
+          id: i.id,
+          title: i.title,
+          column: i.column,
+          sessionCount: info?.count ?? 0,
+          sessionKind: info?.kind,
+          agentState: info?.agentState,
+        };
+      });
+    },
+
+    getSessionDiagnostics() {
+      const tabs = terminalPanel.getTabSnapshots();
+      const counts = listPanel.getSessionCounts();
+      const tabsByState: Record<string, number> = {};
+      let agentTabs = 0;
+      let shellTabs = 0;
+      for (const tab of tabs) {
+        tabsByState[tab.agentState] = (tabsByState[tab.agentState] ?? 0) + 1;
+        if (tab.sessionType === "shell") {
+          shellTabs++;
+        } else {
+          agentTabs++;
+        }
+      }
+      return {
+        totalItems: listPanel.getItems().length,
+        totalTabs: tabs.length,
+        activeTabIndex: terminalPanel.getActiveIndex(),
+        itemsWithSessions: counts.size,
+        agentTabs,
+        shellTabs,
+        tabsByState,
+      };
+    },
+  };
+
+  window.__workTerminalDebug = api;
+  console.log("[work-terminal] Debug API installed on window.__workTerminalDebug");
+}
+
+/** Remove the debug API from window. */
+export function removeDebugApi(): void {
+  delete window.__workTerminalDebug;
+}

--- a/src/webview/listPanel.ts
+++ b/src/webview/listPanel.ts
@@ -69,6 +69,13 @@ export class ListPanel {
   // Public API
   // ---------------------------------------------------------------------------
 
+  /** Read-only snapshot of items (used by debugApi.ts). */
+  getItems(): WorkItemDTO[] { return this.state.items; }
+  /** Read-only snapshot of columns (used by debugApi.ts). */
+  getColumns(): string[] { return this.state.columns; }
+  /** Read-only snapshot of session counts (used by debugApi.ts). */
+  getSessionCounts(): Map<string, SessionInfo> { return this.state.sessionCounts; }
+
   updateItems(items: WorkItemDTO[], columns: string[]): void {
     this.state.items = items;
     this.state.columns = columns;

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -3,6 +3,7 @@ import type { WebviewMessage, ExtensionMessage } from "./messages";
 import { ListPanel } from "./listPanel";
 import { TerminalPanel } from "./terminalPanel";
 import { renderProfileList, renderProfileEditor } from "./profileManager";
+import { installDebugApi, removeDebugApi } from "./debugApi";
 import type { AgentProfile, AgentType, ParamPassMode, ProfileIcon, BorderStyle } from "../core/agents/types";
 
 const vscode: WebviewApi = acquireVsCodeApi();
@@ -95,6 +96,13 @@ window.addEventListener("message", (event: MessageEvent<ExtensionMessage>) => {
       break;
     case "focusFilter":
       showFilter();
+      break;
+    case "debugApiState":
+      if (message.enabled && listPanel && terminalPanel) {
+        installDebugApi(listPanel, terminalPanel);
+      } else {
+        removeDebugApi();
+      }
       break;
     default:
       break;

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -100,4 +100,5 @@ export type ExtensionMessage =
   | { type: "failPlaceholder"; placeholderId: string }
   | { type: "buttonProfiles"; profiles: ButtonProfileInfo[] }
   | { type: "resumeItemIds"; itemIds: string[] }
-  | { type: "hookBannerState"; visible: boolean; message: string };
+  | { type: "hookBannerState"; visible: boolean; message: string }
+  | { type: "debugApiState"; enabled: boolean };

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -184,6 +184,18 @@ export class TerminalPanel {
   }
 
   // -------------------------------------------------------------------------
+  // Debug accessors (used by debugApi.ts)
+  // -------------------------------------------------------------------------
+
+  /** Snapshot of all tab metadata (excludes live Terminal instances). */
+  getTabSnapshots(): Array<{ sessionId: string; label: string; sessionType: string; itemId: string | null; agentState: string }> {
+    return this.tabs.map((t) => ({ sessionId: t.sessionId, label: t.label, sessionType: t.sessionType, itemId: t.itemId, agentState: t.agentState }));
+  }
+
+  /** Current active tab index. */
+  getActiveIndex(): number { return this.activeIndex; }
+
+  // -------------------------------------------------------------------------
   // Terminal lifecycle
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Exposes `window.__workTerminalDebug` in the webview when `workTerminal.exposeDebugApi` setting is enabled
- Provides 6 read-only inspection methods: `getSnapshot()`, `getAllActiveTabs()`, `findTabsByLabel(label)`, `getActiveSessionIds()`, `getPersistedSessions(itemId?)`, `getSessionDiagnostics()`
- Debug API installs/removes dynamically when the setting changes at runtime

Closes #79

## Test plan

- [x] `pnpm test` passes (134 tests)
- [x] `pnpm build` succeeds
- [ ] Enable `workTerminal.exposeDebugApi` in settings, open the webview, and verify `window.__workTerminalDebug` is available in the webview DevTools console
- [ ] Call each method and verify correct output
- [ ] Toggle the setting off and verify the API is removed from window

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>