### PR TITLE
Preserve Alt+digit printable characters in terminal

### DIFF
--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -773,6 +773,13 @@ export class TerminalPanel {
     terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
       if (event.type !== "keydown") return true;
 
+      // AltGraph combos (e.g. right-Alt on Windows/Linux) produce printable
+      // characters on many keyboard layouts - pass them through as text input.
+      if (event.getModifierState("AltGraph") && event.key.length === 1) {
+        sendInput(event.key);
+        return false;
+      }
+
       if (event.altKey && !event.metaKey && !event.ctrlKey) {
         switch (event.key) {
           case "ArrowLeft":   sendInput("\x1bb");     return false;
@@ -781,6 +788,12 @@ export class TerminalPanel {
           case "b":           sendInput("\x1bb");     return false;
           case "f":           sendInput("\x1bf");     return false;
           case "d":           sendInput("\x1bd");     return false;
+        }
+        // Alt/Option + key producing a printable character (e.g. Alt+3 = #
+        // on UK keyboard) - send as text rather than an escape sequence.
+        if (event.key.length === 1) {
+          sendInput(event.key);
+          return false;
         }
       }
 


### PR DESCRIPTION
## Summary

- Preserves Alt/Option+digit key presses as text input (e.g. Alt+3 = `#` on UK keyboard) instead of letting xterm convert them to escape sequences
- Passes through AltGraph key combinations (right-Alt on Windows/Linux) that produce printable characters
- Existing Alt+key bindings (arrows, backspace, b/f/d) are unaffected since they match before the new fallback

Closes #86

## Test plan

- [ ] On a UK Mac keyboard, verify Alt+3 types `#` in the terminal
- [ ] Verify Alt+2 types `€` (or layout-appropriate character)
- [ ] Verify existing Alt+arrow, Alt+b, Alt+f, Alt+d still work as word navigation
- [ ] On a Windows/Linux keyboard with AltGraph, verify right-Alt+key produces the expected character

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>