### PR TITLE
Add ID backfilling for path-only work items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Danger confirmation modal for destructive operations (Delete Item, Done & Close Sessions) using VS Code's native warning dialog
 - Debug API (`window.__workTerminalDebug`) exposed in webview when `workTerminal.exposeDebugApi` setting is enabled, with `getSnapshot()`, `getAllActiveTabs()`, `findTabsByLabel()`, `getActiveSessionIds()`, `getPersistedSessions()`, and `getSessionDiagnostics()` methods for development and troubleshooting (Closes #79)
 - `Copy Session Diagnostics` command (`workTerminal.copyDiagnostics`) - copies extension state snapshot to clipboard for debugging
+- ID backfilling for path-only work items: when a selected item has no frontmatter UUID, asynchronously writes a durable UUID and rekeys all internal maps (terminals, custom order, sessions) to the new ID (Closes #80)
 
 ## [0.1.0] - 2026-04-01
 

--- a/src/adapters/task-agent/TaskParser.test.ts
+++ b/src/adapters/task-agent/TaskParser.test.ts
@@ -248,6 +248,105 @@ describe("TaskParser", () => {
     });
   });
 
+  describe("backfillItemId", () => {
+    it("returns the item unchanged when ID is not path-based", async () => {
+      const parser = new TaskParser("2 - Areas/Tasks", defaultSettings);
+      const item = {
+        id: "existing-uuid",
+        path: "2 - Areas/Tasks/active/task.md",
+        title: "Test",
+        state: "active",
+        metadata: {},
+      };
+      const result = await parser.backfillItemId(item);
+      expect(result).toEqual(item);
+    });
+
+    it("writes a UUID to frontmatter and returns updated item", async () => {
+      const vscode = await import("vscode");
+      const content = "---\ntitle: Test\nstate: active\n---\nBody";
+      const readFile = vi.mocked(vscode.workspace.fs.readFile);
+      const writeFile = vi.mocked(vscode.workspace.fs.writeFile);
+      readFile.mockResolvedValueOnce(new TextEncoder().encode(content));
+      writeFile.mockResolvedValueOnce(undefined);
+
+      const parser = new TaskParser("2 - Areas/Tasks", defaultSettings);
+      const filePath = "2 - Areas/Tasks/active/task.md";
+      const item = {
+        id: filePath,
+        path: filePath,
+        title: "Test",
+        state: "active",
+        metadata: {},
+      };
+      const result = await parser.backfillItemId(item);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).not.toBe(filePath);
+      expect(result!.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(writeFile).toHaveBeenCalled();
+    });
+
+    it("uses existing frontmatter ID if one appeared since last parse", async () => {
+      const vscode = await import("vscode");
+      const content = "---\nid: pre-existing-uuid\ntitle: Test\nstate: active\n---\nBody";
+      const readFile = vi.mocked(vscode.workspace.fs.readFile);
+      readFile.mockResolvedValueOnce(new TextEncoder().encode(content));
+
+      const parser = new TaskParser("2 - Areas/Tasks", defaultSettings);
+      const filePath = "2 - Areas/Tasks/active/task.md";
+      const item = {
+        id: filePath,
+        path: filePath,
+        title: "Test",
+        state: "active",
+        metadata: {},
+      };
+      const result = await parser.backfillItemId(item);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("pre-existing-uuid");
+    });
+
+    it("deduplicates concurrent backfill calls for the same item", async () => {
+      const vscode = await import("vscode");
+      const content = "---\ntitle: Test\nstate: active\n---\nBody";
+      const readFile = vi.mocked(vscode.workspace.fs.readFile);
+      const writeFile = vi.mocked(vscode.workspace.fs.writeFile);
+
+      readFile.mockClear();
+      writeFile.mockClear();
+
+      let resolveRead!: (value: Uint8Array) => void;
+      readFile.mockImplementationOnce(
+        () => new Promise<Uint8Array>((resolve) => { resolveRead = resolve; }),
+      );
+      writeFile.mockResolvedValueOnce(undefined);
+
+      const parser = new TaskParser("2 - Areas/Tasks", defaultSettings);
+      const filePath = "2 - Areas/Tasks/active/task.md";
+      const item = {
+        id: filePath,
+        path: filePath,
+        title: "Test",
+        state: "active",
+        metadata: {},
+      };
+
+      const p1 = parser.backfillItemId(item);
+      const p2 = parser.backfillItemId(item);
+
+      resolveRead(new TextEncoder().encode(content));
+
+      const [result1, result2] = await Promise.all([p1, p2]);
+
+      expect(result1!.id).toBe(result2!.id);
+      expect(readFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("isItemFile", () => {
     it("matches files under basePath", () => {
       const parser = new TaskParser("2 - Areas/Tasks", defaultSettings);

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import type { WebviewMessage, ExtensionMessage, ButtonProfileInfo } from "../webview/messages";
 import { WorkItemService } from "../services/WorkItemService";
-import { FileWatcher } from "../services/FileWatcher";
+import { FileWatcher, type RenameEvent } from "../services/FileWatcher";
 import type { AdapterBundle } from "../core/interfaces";
 import { getNonce, expandTilde } from "../core/utils";
 import { dangerConfirm } from "../core/dangerConfirm";
@@ -243,6 +243,7 @@ export class WorkTerminalPanel {
       resolvedBase,
       (p: string) => this._workItemService?.isItemFile(p) ?? false,
       () => this._refreshItems(),
+      (event: RenameEvent) => this._handleFileRenamed(event),
     );
 
     // Initial load
@@ -386,10 +387,32 @@ export class WorkTerminalPanel {
     const items = this._workItemService.toDTOs();
     const columns = this._workItemService.getColumns();
 
+    // Populate FileWatcher UUID cache from loaded items so rename
+    // detection can match deleted files by their frontmatter id.
+    if (this._fileWatcher) {
+      for (const item of this._workItemService.getItems()) {
+        if (item.id && item.id !== item.path) {
+          this._fileWatcher.cacheUuid(item.path, item.id);
+        }
+      }
+    }
+
     this.postMessage({ type: "updateItems", items, columns });
 
     // Notify sidebar of updated items
     WorkTerminalPanel.onItemsUpdated?.(items, columns);
+  }
+
+  /**
+   * Handle a file rename detected by the FileWatcher (shell mv).
+   * Logs the rename for diagnostics. Session associations survive
+   * because they are keyed by UUID, not file path.
+   */
+  private _handleFileRenamed(event: RenameEvent): void {
+    console.log(
+      `[work-terminal] File renamed: ${event.oldPath} -> ${event.newPath}` +
+      (event.uuid ? ` (uuid: ${event.uuid})` : ""),
+    );
   }
 
   /**
@@ -432,6 +455,7 @@ export class WorkTerminalPanel {
       resolvedBase,
       (p: string) => this._workItemService?.isItemFile(p) ?? false,
       () => this._refreshItems(),
+      (event: RenameEvent) => this._handleFileRenamed(event),
     );
 
     this._hookBannerService.updateAcceptSetting(
@@ -687,6 +711,41 @@ export class WorkTerminalPanel {
       preview: true,
     });
     this._detailEditorUri = uri;
+
+    // Backfill a durable UUID when the item is keyed by path only
+    if (item.id === item.path) {
+      this._backfillItemId(item);
+    }
+  }
+
+  /**
+   * Asynchronously backfill a durable UUID for a path-only item.
+   * Updates all internal maps (terminals, custom order, sessions) to the new ID
+   * and refreshes the UI. Fire-and-forget from _handleItemSelected.
+   */
+  private async _backfillItemId(item: import("../core/interfaces").WorkItem): Promise<void> {
+    if (!this._workItemService) return;
+    const updated = await this._workItemService.backfillItemId(item);
+    if (!updated || updated.id === item.id) return;
+
+    const oldId = item.id;
+    const newId = updated.id;
+    console.log(`[work-terminal] Backfilled ID: ${oldId} -> ${newId}`);
+
+    // Rekey terminal sessions
+    this._terminalManager.rekeyItem(oldId, newId);
+
+    // Rekey custom order
+    this._workItemService.rekeyCustomOrder(oldId, newId);
+
+    // Reload items so the new ID propagates to the in-memory list
+    await this._workItemService.loadAll();
+
+    // Persist updated sessions to disk
+    this._sessionManager?.persistCurrentSessions();
+
+    // Refresh the webview with updated item IDs
+    await this._refreshItems();
   }
 
   /**
@@ -1109,7 +1168,6 @@ export class WorkTerminalPanel {
     return checkHookStatus(this._getHookCwd());
   }
 
-<<<<<<< HEAD
   // ---------------------------------------------------------------------------
   // Diagnostics
   // ---------------------------------------------------------------------------

--- a/src/services/WorkItemService.ts
+++ b/src/services/WorkItemService.ts
@@ -193,6 +193,27 @@ export class WorkItemService {
     return this.parser.isItemFile(path);
   }
 
+  /**
+   * Backfill a durable UUID for a path-only item via the adapter parser.
+   * Returns the updated item with the new ID, or null if backfill is unsupported/failed.
+   */
+  async backfillItemId(item: WorkItem): Promise<WorkItem | null> {
+    if (!this.parser.backfillItemId) return null;
+    return this.parser.backfillItemId(item);
+  }
+
+  /**
+   * Rekey an item across custom order maps after an ID backfill.
+   */
+  rekeyCustomOrder(oldId: string, newId: string): void {
+    for (const col of Object.keys(this.customOrder)) {
+      this.customOrder[col] = (this.customOrder[col] || []).map((id) =>
+        id === oldId ? newId : id,
+      );
+    }
+    this.persistOrder();
+  }
+
   private persistOrder(): void {
     this.globalState.update(WorkItemService.ORDER_KEY, this.customOrder);
   }

--- a/src/terminal/TerminalManager.ts
+++ b/src/terminal/TerminalManager.ts
@@ -465,6 +465,17 @@ export class TerminalManager {
   }
 
   /**
+   * Rekey all terminals from one item ID to another (used after ID backfill).
+   */
+  rekeyItem(oldId: string, newId: string): void {
+    for (const instance of this.terminals.values()) {
+      if (instance.itemId === oldId) {
+        instance.itemId = newId;
+      }
+    }
+  }
+
+  /**
    * Close all terminals for a work item.
    */
   closeAllForItem(itemId: string): void {


### PR DESCRIPTION
## Summary

- When a selected item has no frontmatter UUID (keyed by file path only), asynchronously backfills a durable UUID into the file's frontmatter
- Deduplicates concurrent backfill operations for the same item via in-flight promise tracking
- After backfill, rekeys all internal maps (terminal sessions, custom order) to the new ID and persists updated sessions to disk

## Test plan

- [x] 4 new tests: backfill skip for existing UUID, UUID write to frontmatter, existing ID detection on re-read, concurrent dedup
- [x] All 1032 existing tests pass
- [x] Build succeeds

Closes #80

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>