### PR TITLE
Add rename detection for shell mv operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Debug API (`window.__workTerminalDebug`) exposed in webview when `workTerminal.exposeDebugApi` setting is enabled, with `getSnapshot()`, `getAllActiveTabs()`, `findTabsByLabel()`, `getActiveSessionIds()`, `getPersistedSessions()`, and `getSessionDiagnostics()` methods for development and troubleshooting (Closes #79)
 - `Copy Session Diagnostics` command (`workTerminal.copyDiagnostics`) - copies extension state snapshot to clipboard for debugging
 - ID backfilling for path-only work items: when a selected item has no frontmatter UUID, asynchronously writes a durable UUID and rekeys all internal maps (terminals, custom order, sessions) to the new ID (Closes #80)
+- Rename detection for shell `mv` operations: FileWatcher buffers delete events for 2 seconds and matches subsequent creates by UUID (with folder heuristic fallback), treating them as renames instead of delete+create cycles (Closes #81)
 
 ## [0.1.0] - 2026-04-01
 

--- a/src/services/FileWatcher.test.ts
+++ b/src/services/FileWatcher.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Capture watcher event handlers registered during construction
+let onDidCreateHandler: ((uri: { fsPath: string }) => void) | null = null;
+let onDidChangeHandler: ((uri: { fsPath: string }) => void) | null = null;
+let onDidDeleteHandler: ((uri: { fsPath: string }) => void) | null = null;
+
+const { mockReadFile } = vi.hoisted(() => ({
+  mockReadFile: vi.fn().mockResolvedValue(new Uint8Array()),
+}));
+
+vi.mock("vscode", () => ({
+  workspace: {
+    fs: {
+      readFile: mockReadFile,
+    },
+    createFileSystemWatcher: vi.fn().mockReturnValue({
+      onDidCreate: vi.fn((handler: (uri: { fsPath: string }) => void) => {
+        onDidCreateHandler = handler;
+        return { dispose: vi.fn() };
+      }),
+      onDidChange: vi.fn((handler: (uri: { fsPath: string }) => void) => {
+        onDidChangeHandler = handler;
+        return { dispose: vi.fn() };
+      }),
+      onDidDelete: vi.fn((handler: (uri: { fsPath: string }) => void) => {
+        onDidDeleteHandler = handler;
+        return { dispose: vi.fn() };
+      }),
+      dispose: vi.fn(),
+    }),
+  },
+  RelativePattern: vi.fn().mockImplementation((base: string, pattern: string) => ({
+    base,
+    pattern,
+  })),
+}));
+
+import { FileWatcher, type RenameEvent } from "./FileWatcher";
+
+// Helper to build frontmatter content
+function mdWithId(uuid: string): Uint8Array {
+  return new TextEncoder().encode(`---\nid: ${uuid}\ntitle: Test\n---\n\nBody`);
+}
+
+function mdWithoutId(): Uint8Array {
+  return new TextEncoder().encode(`---\ntitle: Test\n---\n\nBody`);
+}
+
+describe("FileWatcher rename detection", () => {
+  let watcher: FileWatcher;
+  let onChanged: ReturnType<typeof vi.fn>;
+  let onRenamed: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onChanged = vi.fn();
+    onRenamed = vi.fn();
+
+    // Reset handlers
+    onDidCreateHandler = null;
+    onDidChangeHandler = null;
+    onDidDeleteHandler = null;
+
+    mockReadFile.mockReset();
+    mockReadFile.mockResolvedValue(new Uint8Array());
+
+    watcher = new FileWatcher(
+      "/base",
+      () => true,
+      onChanged,
+      onRenamed,
+    );
+  });
+
+  afterEach(() => {
+    watcher.dispose();
+    vi.useRealTimers();
+  });
+
+  it("buffers delete events for RENAME_BUFFER_MS before firing refresh", () => {
+    onDidDeleteHandler!({ fsPath: "/base/active/test.md" });
+
+    // Refresh should not fire immediately
+    expect(onChanged).not.toHaveBeenCalled();
+
+    // Advance past debounce but within rename buffer
+    vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+    expect(onChanged).not.toHaveBeenCalled();
+
+    // Advance past rename buffer - now the delete fires refresh
+    vi.advanceTimersByTime(FileWatcher.RENAME_BUFFER_MS);
+    // The buffered delete callback fires, then scheduleRefresh debounce
+    vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects rename via UUID match (delete then create with same UUID)", async () => {
+    const uuid = "abc-123-def";
+
+    // Pre-cache the UUID for the old path
+    watcher.cacheUuid("/base/active/test.md", uuid);
+
+    // Simulate the new file having the same UUID
+    mockReadFile.mockResolvedValue(mdWithId(uuid));
+
+    // Delete old path
+    onDidDeleteHandler!({ fsPath: "/base/active/test.md" });
+
+    // Create new path (within rename buffer window)
+    vi.advanceTimersByTime(100);
+    onDidCreateHandler!({ fsPath: "/base/todo/test.md" });
+
+    // Flush the async readFile promise
+    await vi.waitFor(() => {
+      expect(onRenamed).toHaveBeenCalledTimes(1);
+    });
+
+    const event: RenameEvent = onRenamed.mock.calls[0][0];
+    expect(event.oldPath).toBe("/base/active/test.md");
+    expect(event.newPath).toBe("/base/todo/test.md");
+    expect(event.uuid).toBe(uuid);
+
+    // Should schedule a single refresh (not the buffered delete one)
+    vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    // The buffered delete timer should have been cancelled
+    vi.advanceTimersByTime(FileWatcher.RENAME_BUFFER_MS);
+    // Extra debounce wait
+    vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects rename via folder heuristic (same filename, no UUID)", async () => {
+    // No UUID cached, no UUID in file
+    mockReadFile.mockResolvedValue(mdWithoutId());
+
+    // Delete from one folder
+    onDidDeleteHandler!({ fsPath: "/base/active/my-task.md" });
+
+    // Create in another folder with same filename
+    vi.advanceTimersByTime(50);
+    onDidCreateHandler!({ fsPath: "/base/done/my-task.md" });
+
+    await vi.waitFor(() => {
+      expect(onRenamed).toHaveBeenCalledTimes(1);
+    });
+
+    const event: RenameEvent = onRenamed.mock.calls[0][0];
+    expect(event.oldPath).toBe("/base/active/my-task.md");
+    expect(event.newPath).toBe("/base/done/my-task.md");
+    expect(event.uuid).toBeNull();
+  });
+
+  it("does not match rename when UUIDs differ", async () => {
+    watcher.cacheUuid("/base/active/test.md", "uuid-old");
+    mockReadFile.mockResolvedValue(mdWithId("uuid-different"));
+
+    onDidDeleteHandler!({ fsPath: "/base/active/test.md" });
+
+    vi.advanceTimersByTime(100);
+    onDidCreateHandler!({ fsPath: "/base/todo/other.md" });
+
+    // Wait for async
+    await vi.waitFor(() => {
+      // The create should have triggered a refresh schedule
+      vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+      expect(onChanged).toHaveBeenCalled();
+    });
+
+    expect(onRenamed).not.toHaveBeenCalled();
+  });
+
+  it("does not use folder heuristic when UUID is available on delete side", async () => {
+    // Deleted file has a UUID cached, but new file has no UUID
+    watcher.cacheUuid("/base/active/my-task.md", "cached-uuid");
+    mockReadFile.mockResolvedValue(mdWithoutId());
+
+    onDidDeleteHandler!({ fsPath: "/base/active/my-task.md" });
+
+    vi.advanceTimersByTime(50);
+    onDidCreateHandler!({ fsPath: "/base/done/my-task.md" });
+
+    // Wait for async resolution
+    await vi.waitFor(() => {
+      vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+      expect(onChanged).toHaveBeenCalled();
+    });
+
+    // No rename: folder heuristic only fires when neither side has UUID
+    expect(onRenamed).not.toHaveBeenCalled();
+  });
+
+  it("processes delete normally when no create arrives within buffer window", () => {
+    onDidDeleteHandler!({ fsPath: "/base/active/test.md" });
+
+    // Wait for full buffer window + debounce
+    vi.advanceTimersByTime(FileWatcher.RENAME_BUFFER_MS + FileWatcher.DEBOUNCE_MS + 50);
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onRenamed).not.toHaveBeenCalled();
+  });
+
+  it("fires onChanged for regular update events without delay", () => {
+    onDidChangeHandler!({ fsPath: "/base/active/test.md" });
+
+    // Just debounce delay, no rename buffer
+    vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onChanged for create events that have no matching delete", async () => {
+    mockReadFile.mockResolvedValue(mdWithId("some-uuid"));
+
+    onDidCreateHandler!({ fsPath: "/base/active/new-file.md" });
+
+    await vi.waitFor(() => {
+      vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+      expect(onChanged).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onRenamed).not.toHaveBeenCalled();
+  });
+
+  it("cacheUuid and evictUuid manage the internal cache", async () => {
+    const uuid = "test-uuid";
+
+    watcher.cacheUuid("/base/active/test.md", uuid);
+
+    // After caching, a delete + create with matching UUID should detect rename
+    mockReadFile.mockResolvedValue(mdWithId(uuid));
+
+    onDidDeleteHandler!({ fsPath: "/base/active/test.md" });
+    vi.advanceTimersByTime(50);
+    onDidCreateHandler!({ fsPath: "/base/todo/test.md" });
+
+    await vi.waitFor(() => {
+      expect(onRenamed).toHaveBeenCalledTimes(1);
+    });
+
+    // Now evict and try again - should not match
+    onRenamed.mockClear();
+    watcher.evictUuid("/base/todo/test.md");
+
+    mockReadFile.mockResolvedValue(mdWithId("another-uuid"));
+
+    onDidDeleteHandler!({ fsPath: "/base/todo/test.md" });
+    vi.advanceTimersByTime(50);
+    onDidCreateHandler!({ fsPath: "/base/active/test.md" });
+
+    // Wait for async resolution
+    await vi.waitFor(() => {
+      vi.advanceTimersByTime(FileWatcher.DEBOUNCE_MS + 50);
+      expect(onChanged).toHaveBeenCalled();
+    });
+
+    // No rename because the delete had no cached UUID, and new file has a different UUID
+    expect(onRenamed).not.toHaveBeenCalled();
+  });
+
+  it("cleans up timers on dispose", () => {
+    onDidDeleteHandler!({ fsPath: "/base/active/test.md" });
+
+    // Dispose before buffer timeout
+    watcher.dispose();
+
+    // Advance past buffer window
+    vi.advanceTimersByTime(FileWatcher.RENAME_BUFFER_MS + FileWatcher.DEBOUNCE_MS + 100);
+
+    // onChanged should not have been called since we disposed
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/FileWatcher.ts
+++ b/src/services/FileWatcher.ts
@@ -1,57 +1,213 @@
 import * as vscode from "vscode";
+import { extractFrontmatterString } from "../core/frontmatter";
+
+/**
+ * Buffered delete entry. Holds metadata about a recently deleted file
+ * so we can match it against a subsequent create (rename detection).
+ */
+interface BufferedDelete {
+  /** Absolute filesystem path of the deleted file. */
+  fsPath: string;
+  /** Timestamp of the delete event. */
+  timestamp: number;
+  /** UUID extracted from the file before deletion (if cached), or null. */
+  uuid: string | null;
+  /** Timer that fires the actual delete processing after the buffer window. */
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface RenameEvent {
+  /** Previous absolute filesystem path. */
+  oldPath: string;
+  /** New absolute filesystem path. */
+  newPath: string;
+  /** UUID of the item (if available). */
+  uuid: string | null;
+}
 
 /**
  * Extension-host side file watcher.
  * Watches the task base path for .md file changes and fires a debounced
- * callback. Works with any adapter - does not hardcode paths.
+ * callback. Buffers delete events to detect shell mv renames via
+ * UUID matching with a folder heuristic fallback.
  */
 export class FileWatcher implements vscode.Disposable {
   private watcher: vscode.FileSystemWatcher;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  private recentDeletes: Map<string, number> = new Map();
+  private bufferedDeletes: Map<string, BufferedDelete> = new Map();
+  private uuidCache: Map<string, string> = new Map();
   private disposables: vscode.Disposable[] = [];
 
-  private static DEBOUNCE_MS = 300;
-  private static RENAME_WINDOW_MS = 500;
+  static DEBOUNCE_MS = 300;
+  static RENAME_BUFFER_MS = 2000;
 
   constructor(
-    basePath: string,
+    private basePath: string,
     private isItemFile: (path: string) => boolean,
     private onChanged: () => void,
+    private onRenamed?: (event: RenameEvent) => void,
   ) {
     const pattern = new vscode.RelativePattern(basePath, "**/*.md");
     this.watcher = vscode.workspace.createFileSystemWatcher(pattern);
 
     this.disposables.push(
-      this.watcher.onDidCreate((uri) => this.handleChange(uri, "create")),
-      this.watcher.onDidChange((uri) => this.handleChange(uri, "update")),
-      this.watcher.onDidDelete((uri) => this.handleChange(uri, "delete")),
+      this.watcher.onDidCreate((uri) => this.handleCreate(uri)),
+      this.watcher.onDidChange((uri) => this.handleUpdate(uri)),
+      this.watcher.onDidDelete((uri) => this.handleDelete(uri)),
     );
   }
 
-  private handleChange(uri: vscode.Uri, kind: "create" | "update" | "delete"): void {
+  /**
+   * Cache a file's UUID so rename detection can match after deletion.
+   * Called externally when items are loaded/parsed and their UUIDs are known.
+   */
+  cacheUuid(fsPath: string, uuid: string): void {
+    this.uuidCache.set(fsPath, uuid);
+  }
+
+  /**
+   * Remove a cached UUID entry (e.g. when a file is confirmed deleted).
+   */
+  evictUuid(fsPath: string): void {
+    this.uuidCache.delete(fsPath);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+
+  private async handleCreate(uri: vscode.Uri): Promise<void> {
     const fsPath = uri.fsPath;
 
-    // Delete-create rename detection: if a file is created shortly after
-    // a delete at a similar path, treat it as a rename (single refresh).
-    if (kind === "delete") {
-      this.recentDeletes.set(fsPath, Date.now());
-      setTimeout(() => this.recentDeletes.delete(fsPath), FileWatcher.RENAME_WINDOW_MS);
+    // Try to read UUID from the newly created file
+    const newUuid = await this.readUuidFromFile(uri);
+
+    // Check buffered deletes for a rename match
+    const match = this.findRenameMatch(fsPath, newUuid);
+
+    if (match) {
+      // Cancel the buffered delete's timeout - it won't fire as a real delete
+      clearTimeout(match.timer);
+      this.bufferedDeletes.delete(match.fsPath);
+
+      // Update UUID cache: remove old path, add new path
+      if (match.uuid) {
+        this.uuidCache.delete(match.fsPath);
+      }
+      if (newUuid) {
+        this.uuidCache.set(fsPath, newUuid);
+      }
+
+      console.log(
+        `[work-terminal] Rename detected: ${match.fsPath} -> ${fsPath}` +
+        (newUuid ? ` (uuid: ${newUuid})` : " (folder heuristic)"),
+      );
+
+      this.onRenamed?.({
+        oldPath: match.fsPath,
+        newPath: fsPath,
+        uuid: newUuid ?? match.uuid,
+      });
+
+      // Single refresh for the rename
+      this.scheduleRefresh();
+      return;
     }
 
-    if (kind === "create") {
-      // Check if this looks like the second half of a rename
-      for (const [deletedPath, ts] of this.recentDeletes) {
-        if (Date.now() - ts < FileWatcher.RENAME_WINDOW_MS && deletedPath !== fsPath) {
-          this.recentDeletes.delete(deletedPath);
-          // Still triggers refresh, just don't double-fire
-          break;
+    // No rename match - normal create
+    if (newUuid) {
+      this.uuidCache.set(fsPath, newUuid);
+    }
+    this.scheduleRefresh();
+  }
+
+  private handleUpdate(_uri: vscode.Uri): void {
+    // Content change - just refresh. UUID could have been added/changed,
+    // but re-reading on every save would be expensive. The parser will
+    // pick up changes on the next loadAll().
+    this.scheduleRefresh();
+  }
+
+  private handleDelete(uri: vscode.Uri): void {
+    const fsPath = uri.fsPath;
+
+    // Buffer the delete: wait for a matching create before processing
+    const cachedUuid = this.uuidCache.get(fsPath) ?? null;
+
+    const timer = setTimeout(() => {
+      // No matching create arrived within the buffer window - real delete
+      this.bufferedDeletes.delete(fsPath);
+      this.uuidCache.delete(fsPath);
+      this.scheduleRefresh();
+    }, FileWatcher.RENAME_BUFFER_MS);
+
+    this.bufferedDeletes.set(fsPath, {
+      fsPath,
+      timestamp: Date.now(),
+      uuid: cachedUuid,
+      timer,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rename matching
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Find a buffered delete that matches a newly created file.
+   *
+   * Match strategy (in priority order):
+   * 1. UUID match: the deleted file's cached UUID matches the new file's UUID
+   * 2. Folder heuristic: same filename, different parent folder (state move)
+   */
+  private findRenameMatch(newPath: string, newUuid: string | null): BufferedDelete | null {
+    const now = Date.now();
+
+    for (const [, entry] of this.bufferedDeletes) {
+      // Skip expired entries (shouldn't happen since timer cleans up, but be safe)
+      if (now - entry.timestamp > FileWatcher.RENAME_BUFFER_MS) continue;
+      // Don't match a file with itself
+      if (entry.fsPath === newPath) continue;
+
+      // Strategy 1: UUID match
+      if (newUuid && entry.uuid && newUuid === entry.uuid) {
+        return entry;
+      }
+
+      // Strategy 2: Folder heuristic - same filename, different directory
+      if (!newUuid && !entry.uuid) {
+        const newFilename = newPath.split("/").pop();
+        const oldFilename = entry.fsPath.split("/").pop();
+        if (newFilename && oldFilename && newFilename === oldFilename) {
+          return entry;
         }
       }
     }
 
-    this.scheduleRefresh();
+    return null;
   }
+
+  // ---------------------------------------------------------------------------
+  // UUID reading
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Read UUID from a file's frontmatter. Returns null if the file can't be
+   * read or has no id field.
+   */
+  private async readUuidFromFile(uri: vscode.Uri): Promise<string | null> {
+    try {
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      const content = new TextDecoder().decode(bytes);
+      return extractFrontmatterString(content, "id");
+    } catch {
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scheduling
+  // ---------------------------------------------------------------------------
 
   private scheduleRefresh(): void {
     if (this.debounceTimer) {
@@ -67,6 +223,12 @@ export class FileWatcher implements vscode.Disposable {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
+    // Clear all buffered delete timers
+    for (const [, entry] of this.bufferedDeletes) {
+      clearTimeout(entry.timer);
+    }
+    this.bufferedDeletes.clear();
+    this.uuidCache.clear();
     this.watcher.dispose();
     for (const d of this.disposables) {
       d.dispose();


### PR DESCRIPTION
## Summary

- Replaces the basic 500ms rename window in FileWatcher with a 2-second buffered delete system that uses UUID matching (with folder heuristic fallback) to detect shell `mv` renames
- Buffers delete events and matches subsequent creates by frontmatter UUID; falls back to same-filename-different-directory heuristic when UUID is unavailable
- Populates UUID cache from loaded items on each refresh cycle so cached UUIDs are available when files are deleted

Closes #81

## Test plan

- [x] 10 new tests in `FileWatcher.test.ts` covering: buffered deletes, UUID-based rename detection, folder heuristic fallback, mismatched UUIDs, cache management, timer cleanup
- [x] All 1037 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual: `mv` a task file between state folders in a terminal and verify it appears as a rename (single refresh) rather than delete+create

Generated with [Claude Code](https://claude.com/claude-code)