### PR TITLE
Add reset guided tour command

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,12 @@
         "icon": "$(info)"
       },
       {
+        "command": "workTerminal.resetTour",
+        "title": "Reset Guided Tour",
+        "category": "Work Terminal",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "workTerminal.copyDiagnostics",
         "title": "Copy Session Diagnostics",
         "category": "Work Terminal"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,6 +187,20 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
+    vscode.commands.registerCommand("workTerminal.resetTour", async () => {
+      // Clear extension-tracked tour completion state
+      await context.globalState.update("tourCompleted", undefined);
+      // Re-open the walkthrough so the user can go through it again
+      await vscode.commands.executeCommand(
+        "workbench.action.openWalkthrough",
+        "tomcorke.vscode-work-terminal-v2#workTerminal.gettingStarted",
+        false,
+      );
+      vscode.window.showInformationMessage("Guided tour has been reset.");
+    })
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand("workTerminal.copyDiagnostics", async () => {
       const panel = WorkTerminalPanel.current;
       if (!panel) {


### PR DESCRIPTION
## Summary

- Adds `workTerminal.resetTour` command that clears tour completion state from globalState and re-opens the walkthrough
- Registered in package.json with the refresh icon
- Allows users to re-trigger the guided tour after completion

Closes #87

## Test plan

- [ ] Run `Work Terminal: Reset Guided Tour` from the command palette
- [ ] Verify the walkthrough opens
- [ ] Verify the info message "Guided tour has been reset." appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)