### PR TITLE
Add idle tracking timestamps for staggered animations

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -42,6 +42,8 @@ export class WorkTerminalPanel {
   private _profileManager: AgentProfileManager | null = null;
   private readonly _sessionTrackers = new Map<string, AgentSessionTracker>();
   private readonly _hookBannerService = new HookBannerService();
+  /** Tracks when each item last entered idle state (ms timestamp, keyed by itemId). */
+  private readonly _idleSinceMap = new Map<string, number>();
 
   /** URI of the detail editor tab opened by the extension (null if none). */
   private _detailEditorUri: vscode.Uri | null = null;
@@ -109,7 +111,19 @@ export class WorkTerminalPanel {
       this._postResumeItemIds();
     };
     this._terminalManager.onAgentStateChanged = (sessionId, state) => {
-      this.postMessage({ type: "agentStateChanged", sessionId, state });
+      const itemId = this._getItemIdForSession(sessionId) ?? undefined;
+      let idleSince: number | undefined;
+      if (itemId) {
+        if (state === "idle") {
+          if (!this._idleSinceMap.has(itemId)) {
+            this._idleSinceMap.set(itemId, Date.now());
+          }
+          idleSince = this._idleSinceMap.get(itemId);
+        } else {
+          this._idleSinceMap.delete(itemId);
+        }
+      }
+      this.postMessage({ type: "agentStateChanged", sessionId, state, itemId, idleSince });
     };
     this._terminalManager.onRenamed = (sessionId, newLabel) => {
       // Allow adapter to transform the detected label

--- a/src/webview/listPanel.ts
+++ b/src/webview/listPanel.ts
@@ -12,6 +12,7 @@ interface SessionInfo {
   count: number;
   kind: "shell" | "agent" | "mixed";
   agentState?: "active" | "idle" | "waiting";
+  idleSince?: number;
 }
 
 interface PlaceholderCard {
@@ -100,10 +101,11 @@ export class ListPanel {
     this.updateSessionBadge(itemId);
   }
 
-  setAgentState(itemId: string, agentState: "active" | "idle" | "waiting" | null): void {
+  setAgentState(itemId: string, agentState: "active" | "idle" | "waiting" | null, idleSince?: number): void {
     const info = this.state.sessionCounts.get(itemId);
     if (info) {
       info.agentState = agentState || undefined;
+      info.idleSince = agentState === "idle" ? idleSince : undefined;
     }
     this.updateAgentIndicator(itemId);
   }
@@ -514,11 +516,12 @@ export class ListPanel {
     container.appendChild(badge);
 
     // Agent state indicator on the card wrapper
-    const cardEl = container.closest(".wt-card-wrapper");
+    const cardEl = container.closest(".wt-card-wrapper") as HTMLElement | null;
     if (cardEl) {
       cardEl.classList.toggle("wt-agent-active", info.agentState === "active");
       cardEl.classList.toggle("wt-agent-waiting", info.agentState === "waiting");
       cardEl.classList.toggle("wt-agent-idle", info.agentState === "idle");
+      this.applyIdleOffset(cardEl, info);
     }
   }
 
@@ -544,6 +547,17 @@ export class ListPanel {
     card.classList.toggle("wt-agent-active", info?.agentState === "active");
     card.classList.toggle("wt-agent-waiting", info?.agentState === "waiting");
     card.classList.toggle("wt-agent-idle", info?.agentState === "idle");
+    this.applyIdleOffset(card, info);
+  }
+
+  /** Set or remove the --idle-offset CSS variable for staggered idle animations. */
+  private applyIdleOffset(cardEl: HTMLElement, info?: SessionInfo): void {
+    if (info?.agentState === "idle" && info.idleSince) {
+      const elapsed = (Date.now() - info.idleSince) / 1000;
+      cardEl.style.setProperty("--idle-offset", `${-elapsed}s`);
+    } else {
+      cardEl.style.removeProperty("--idle-offset");
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -46,6 +46,9 @@ window.addEventListener("message", (event: MessageEvent<ExtensionMessage>) => {
       break;
     case "agentStateChanged":
       terminalPanel?.updateAgentState(message.sessionId, message.state);
+      if (listPanel && message.itemId) {
+        listPanel.setAgentState(message.itemId, message.state as "active" | "idle" | "waiting" | null, message.idleSince);
+      }
       break;
     case "sessionStateChanged":
       if (listPanel) {

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -79,7 +79,7 @@ export type ExtensionMessage =
   | { type: "terminalCreated"; sessionId: string; label: string; sessionType: string; itemId?: string }
   | { type: "terminalClosed"; sessionId: string }
   | { type: "terminalRenamed"; sessionId: string; label: string }
-  | { type: "agentStateChanged"; sessionId: string; state: string }
+  | { type: "agentStateChanged"; sessionId: string; state: string; itemId?: string; idleSince?: number }
   | {
       type: "sessionStateChanged";
       itemId: string;

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -640,11 +640,43 @@ a.wt-card-source--jira:hover {
   }
 }
 
-/* --- Idle: badge grayscale filter (applied after delay) --- */
+/* --- Idle: depleting arc + desaturation over 300s --- */
 
 .wt-agent-idle .wt-session-badge {
-  filter: grayscale(0.7);
-  transition: filter 2s ease;
+  position: relative;
+  overflow: visible;
+  isolation: isolate;
+  animation: wt-badge-desaturate 300s linear forwards;
+  animation-delay: var(--idle-offset, 0s);
+}
+
+.wt-agent-idle .wt-session-badge::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 12px;
+  background: conic-gradient(var(--vscode-descriptionForeground, #888) 0deg, var(--vscode-descriptionForeground, #888) var(--wt-idle-arc), transparent var(--wt-idle-arc), transparent 360deg);
+  mask: radial-gradient(farthest-side, transparent calc(100% - 2.5px), #000 calc(100% - 2px));
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 2.5px), #000 calc(100% - 2px));
+  animation: wt-badge-deplete 300s linear forwards;
+  animation-delay: var(--idle-offset, 0s);
+  z-index: -1;
+}
+
+@keyframes wt-badge-desaturate {
+  0% { filter: saturate(1); }
+  100% { filter: saturate(0.1); }
+}
+
+@property --wt-idle-arc {
+  syntax: "<angle>";
+  initial-value: 360deg;
+  inherits: false;
+}
+
+@keyframes wt-badge-deplete {
+  0% { --wt-idle-arc: 360deg; }
+  100% { --wt-idle-arc: 0deg; }
 }
 
 /* =============================================================================


### PR DESCRIPTION
## Summary

- Track per-item idle entry timestamps on the extension host and relay them to the webview via the `agentStateChanged` message
- List panel calculates elapsed time since idle entry and sets `--idle-offset` CSS variable on card elements
- Upgraded idle CSS from simple grayscale filter to 300s desaturation animation + depleting conic-gradient arc, both using `animation-delay: var(--idle-offset)` for staggered wave effect across multiple badges

Closes #88

## Test plan

- [x] All 1037 existing tests pass
- [x] Build succeeds
- [ ] Manual: launch multiple agent sessions, let them go idle at different times, verify staggered animation offsets on badges
- [ ] Manual: verify idle animation resets when agent becomes active again

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>