### PR TITLE
Fix launcher buttons missing after panel init

### DIFF
--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -211,6 +211,7 @@ export class WorkTerminalPanel {
   async initProfileManager(globalState: vscode.Memento): Promise<void> {
     this._profileManager = new AgentProfileManager(globalState);
     await this._profileManager.load();
+    this._sendButtonProfiles();
   }
 
   get profileManager(): AgentProfileManager | null {


### PR DESCRIPTION
## Summary
- send launcher button profiles again after the profile manager finishes loading
- cover the init-order race where the webview becomes ready before profiles are available

## Validation
- pnpm test
- pnpm build

## Notes
- `pnpm run lint` is currently not runnable on this branch because the repo script points to `eslint`, but the dependency is not present in package.json