### PR TITLE
Fix duplicate Work Terminal panels from sidebar clicks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,8 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("workTerminal.selectItem", (itemId: string) => {
+    vscode.commands.registerCommand("workTerminal.selectItem", async (itemId: string) => {
+      await vscode.commands.executeCommand("workTerminal.openPanel");
       const panel = WorkTerminalPanel.current;
       if (panel) {
         panel.postMessage({ type: "selectItem", itemId });

--- a/src/panels/SidebarProvider.ts
+++ b/src/panels/SidebarProvider.ts
@@ -49,9 +49,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
           this._pendingMessages = [];
           break;
         case "itemSelected":
-          // Route through the panel's message handler so sidebar selection
-          // follows the same singleton reuse path as other sidebar actions.
-          this._forwardToPanelSafely(message);
+          this._selectItemInPanelSafely(message.id);
           break;
         case "createItem":
           // Forward to panel
@@ -93,6 +91,12 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
   private _forwardToPanelSafely(message: WebviewMessage): void {
     void this._forwardToPanel(message).catch((error: unknown) => {
       console.error("[work-terminal] Failed to forward sidebar message to panel", error);
+    });
+  }
+
+  private _selectItemInPanelSafely(itemId: string): void {
+    void vscode.commands.executeCommand("workTerminal.selectItem", itemId).catch((error: unknown) => {
+      console.error("[work-terminal] Failed to select sidebar item in panel", error);
     });
   }
 

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -36,6 +36,8 @@ export class WorkTerminalPanel {
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionUri: vscode.Uri;
   private _disposed = false;
+  private _webviewReady = false;
+  private readonly _pendingMessages: ExtensionMessage[] = [];
 
   private _workItemService: WorkItemService | null = null;
   private _fileWatcher: FileWatcher | null = null;
@@ -73,6 +75,8 @@ export class WorkTerminalPanel {
       // Best-effort: persist sessions before tearing down.
       this._teardown();
       WorkTerminalPanel.current = undefined;
+      this._webviewReady = false;
+      this._pendingMessages.length = 0;
     });
 
     this._panel.webview.onDidReceiveMessage((message: WebviewMessage) => {
@@ -340,9 +344,12 @@ export class WorkTerminalPanel {
    * Post a typed message to the webview.
    */
   postMessage(message: ExtensionMessage): void {
-    if (!this._disposed) {
+    if (this._disposed) return;
+    if (this._webviewReady) {
       this._panel.webview.postMessage(message);
+      return;
     }
+    this._pendingMessages.push(message);
   }
 
   /**
@@ -522,6 +529,7 @@ export class WorkTerminalPanel {
   private _handleMessage(message: WebviewMessage): void {
     switch (message.type) {
       case "ready": {
+        this._webviewReady = true;
         this._refreshItems();
         this._sendButtonProfiles();
         this._postResumeItemIds();
@@ -531,22 +539,33 @@ export class WorkTerminalPanel {
         if (cfg.get<boolean>("exposeDebugApi", false)) {
           this.postMessage({ type: "debugApiState", enabled: true });
         }
+        this._flushPendingMessages();
         break;
       }
       case "itemSelected":
-        this._handleItemSelected(message.id);
+        this.postMessage({ type: "selectItem", itemId: message.id });
+        this._runMessageTask(this._handleItemSelected(message.id), "select item");
         break;
       case "createItem":
-        this._handleCreateItem(message.title, message.column);
+        this._runMessageTask(
+          this._handleCreateItem(message.title, message.column),
+          "create item",
+        );
         break;
       case "deleteItem":
-        this._handleDeleteItem(message.id);
+        this._runMessageTask(this._handleDeleteItem(message.id), "delete item");
         break;
       case "moveItem":
-        this._handleMoveItem(message.id, message.toColumn, message.index);
+        this._runMessageTask(
+          this._handleMoveItem(message.id, message.toColumn, message.index),
+          "move item",
+        );
         break;
       case "dragDrop":
-        this._handleDragDrop(message.itemId, message.toColumn, message.index);
+        this._runMessageTask(
+          this._handleDragDrop(message.itemId, message.toColumn, message.index),
+          "drag drop",
+        );
         break;
       case "filterChanged":
         // Filtering is handled entirely in the webview
@@ -582,13 +601,19 @@ export class WorkTerminalPanel {
         this._handleGetProfiles();
         break;
       case "saveProfile":
-        this._handleSaveProfile(message.profile);
+        this._runMessageTask(this._handleSaveProfile(message.profile), "save profile");
         break;
       case "deleteProfile":
-        this._handleDeleteProfile(message.profileId);
+        this._runMessageTask(
+          this._handleDeleteProfile(message.profileId),
+          "delete profile",
+        );
         break;
       case "reorderProfiles":
-        this._handleReorderProfiles(message.orderedIds);
+        this._runMessageTask(
+          this._handleReorderProfiles(message.orderedIds),
+          "reorder profiles",
+        );
         break;
       case "launchProfile":
         this._handleLaunchProfile(
@@ -600,43 +625,58 @@ export class WorkTerminalPanel {
         );
         break;
       case "importProfiles":
-        this._handleImportProfiles();
+        this._runMessageTask(this._handleImportProfiles(), "import profiles");
         break;
       case "exportProfiles":
-        this._handleExportProfiles();
+        this._runMessageTask(this._handleExportProfiles(), "export profiles");
         break;
       case "moveProfileUp":
-        this._handleMoveProfile(message.profileId, "up");
+        this._runMessageTask(
+          this._handleMoveProfile(message.profileId, "up"),
+          "move profile up",
+        );
         break;
       case "moveProfileDown":
-        this._handleMoveProfile(message.profileId, "down");
+        this._runMessageTask(
+          this._handleMoveProfile(message.profileId, "down"),
+          "move profile down",
+        );
         break;
       case "copyToClipboard":
         vscode.env.clipboard.writeText(message.text);
         break;
       case "contextMenuMove":
-        this._handleMoveItem(message.itemId, message.toColumn, 0);
+        this._runMessageTask(
+          this._handleMoveItem(message.itemId, message.toColumn, 0),
+          "context move item",
+        );
         break;
       case "contextMenuDelete":
-        this._handleDeleteItem(message.itemId);
+        this._runMessageTask(
+          this._handleDeleteItem(message.itemId),
+          "context delete item",
+        );
         break;
       case "doneAndCloseSessions":
-        this._handleDoneAndCloseSessions(message.itemId);
+        this._runMessageTask(
+          this._handleDoneAndCloseSessions(message.itemId),
+          "done and close sessions",
+        );
         break;
       case "moveToTop":
-        this._handleMoveToTop(message.itemId);
+        this._runMessageTask(this._handleMoveToTop(message.itemId), "move item to top");
         break;
       case "requestLaunchModal":
-        this.showLaunchModal();
+        this.showLaunchModal(message.itemId);
         break;
       case "resumeItem":
-        this._handleResumeItem(message.itemId);
+        this._runMessageTask(this._handleResumeItem(message.itemId), "resume item");
         break;
       case "installHooks":
-        this._handleInstallHooks();
+        this._runMessageTask(this._handleInstallHooks(), "install hooks");
         break;
       case "removeHooks":
-        this.handleRemoveHooks();
+        this._runMessageTask(this.handleRemoveHooks(), "remove hooks");
         break;
       case "dismissHookBanner":
         this._hookBannerService.dismiss();
@@ -644,6 +684,21 @@ export class WorkTerminalPanel {
       default:
         break;
     }
+  }
+
+  private _flushPendingMessages(): void {
+    while (this._pendingMessages.length > 0) {
+      const message = this._pendingMessages.shift();
+      if (message) {
+        this._panel.webview.postMessage(message);
+      }
+    }
+  }
+
+  private _runMessageTask(task: Promise<void>, action: string): void {
+    void task.catch((error: unknown) => {
+      console.error(`[work-terminal] Failed to ${action}:`, error);
+    });
   }
 
   private async _handleCreateItem(title: string, column?: string): Promise<void> {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -78,6 +78,9 @@ window.addEventListener("message", (event: MessageEvent<ExtensionMessage>) => {
       }
       break;
     }
+    case "selectItem":
+      terminalPanel?.selectItem(message.itemId);
+      break;
     case "debugApiState": {
       // Install or remove a terminal-only debug API on window.__workTerminalDebug
       const anyWindow = window as unknown as Record<string, unknown>;

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -37,7 +37,7 @@ export type WebviewMessage =
   | { type: "contextMenuDelete"; itemId: string }
   | { type: "doneAndCloseSessions"; itemId: string }
   | { type: "moveToTop"; itemId: string }
-  | { type: "requestLaunchModal" }
+  | { type: "requestLaunchModal"; itemId?: string }
   | { type: "resumeItem"; itemId: string }
   | { type: "installHooks" }
   | { type: "removeHooks" }

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -152,10 +152,13 @@ export class TerminalPanel {
   private tabs: TerminalTab[] = [];
   private activeIndex = -1;
   private postMessage: (msg: WebviewMessage) => void;
+  private selectedItemId: string | null = null;
   private tabsContainerEl: HTMLElement;
   private tabButtonsEl: HTMLElement;
   private terminalWrapperEl: HTMLElement;
   private emptyStateEl: HTMLElement;
+  private taskTitleEl: HTMLElement;
+  private taskTitleTextEl: HTMLElement;
   private resizeObserver: ResizeObserver;
   private searchBarVisible = false;
   private buttonProfiles: ButtonProfileInfo[] = [];
@@ -170,6 +173,8 @@ export class TerminalPanel {
     this.tabButtonsEl = document.getElementById("tab-buttons")!;
     this.terminalWrapperEl = document.getElementById("terminal-wrapper")!;
     this.emptyStateEl = document.getElementById("empty-state")!;
+    this.taskTitleEl = document.getElementById("task-title")!;
+    this.taskTitleTextEl = document.getElementById("task-title-text")!;
 
     injectXtermCss();
     this.renderSpawnButtons();
@@ -198,6 +203,12 @@ export class TerminalPanel {
   getActiveSessionId(): string | null {
     const tab = this.tabs[this.activeIndex];
     return tab?.sessionId ?? null;
+  }
+
+  selectItem(itemId: string): void {
+    this.selectedItemId = itemId;
+    this.focusSelectedItem();
+    this.syncSelectedItemUi();
   }
 
   // -------------------------------------------------------------------------
@@ -343,6 +354,8 @@ export class TerminalPanel {
     const tab = this.tabs[index];
     tab.containerEl.classList.remove("hidden");
     this.activeIndex = index;
+    this.selectedItemId = tab.itemId;
+    this.syncSelectedItemUi();
 
     requestAnimationFrame(() => {
       try {
@@ -442,6 +455,7 @@ export class TerminalPanel {
    */
   updateWorkItems(items: WorkItemDTO[]): void {
     this.workItems = items;
+    this.syncSelectedItemUi();
   }
 
   /**
@@ -461,7 +475,11 @@ export class TerminalPanel {
     shellBtn.className = "wt-spawn-btn";
     shellBtn.textContent = "+ Shell";
     shellBtn.addEventListener("click", () => {
-      this.postMessage({ type: "createTerminal", terminalType: "shell" });
+      this.postMessage({
+        type: "createTerminal",
+        terminalType: "shell",
+        itemId: this.selectedItemId ?? undefined,
+      });
     });
     this.tabButtonsEl.appendChild(shellBtn);
 
@@ -494,7 +512,11 @@ export class TerminalPanel {
       btn.appendChild(document.createTextNode(profile.label));
       btn.title = `Launch ${profile.label}`;
       btn.addEventListener("click", () => {
-        this.postMessage({ type: "launchProfile", profileId: profile.profileId });
+        this.postMessage({
+          type: "launchProfile",
+          profileId: profile.profileId,
+          itemId: this.selectedItemId ?? undefined,
+        });
       });
       this.tabButtonsEl.appendChild(btn);
     }
@@ -506,17 +528,64 @@ export class TerminalPanel {
     launchBtn.title = "Launch profile";
     launchBtn.setAttribute("aria-label", "Launch profile");
     launchBtn.addEventListener("click", () => {
-      this.postMessage({ type: "requestLaunchModal" });
+      this.postMessage({
+        type: "requestLaunchModal",
+        itemId: this.selectedItemId ?? undefined,
+      });
     });
     this.tabButtonsEl.appendChild(launchBtn);
   }
 
   private updateEmptyState(): void {
-    if (this.tabs.length > 0) {
+    if (this.activeIndex >= 0 && this.activeIndex < this.tabs.length) {
       this.emptyStateEl.style.display = "none";
     } else {
       this.emptyStateEl.style.display = "flex";
     }
+  }
+
+  private focusSelectedItem(): void {
+    if (!this.selectedItemId) {
+      this.clearActiveTerminal();
+      return;
+    }
+
+    const tabIndex = this.tabs.findIndex((tab) => tab.itemId === this.selectedItemId);
+    if (tabIndex >= 0) {
+      this.switchToTab(tabIndex);
+      this.renderTabBar();
+      return;
+    }
+
+    this.clearActiveTerminal();
+  }
+
+  private clearActiveTerminal(): void {
+    for (const tab of this.tabs) {
+      tab.containerEl.classList.add("hidden");
+    }
+    this.activeIndex = -1;
+    this.renderTabBar();
+    this.updateEmptyState();
+  }
+
+  private syncSelectedItemUi(): void {
+    const selectedItem = this.selectedItemId
+      ? this.workItems.find((item) => item.id === this.selectedItemId) ?? null
+      : null;
+
+    if (!selectedItem) {
+      this.taskTitleEl.style.display = "none";
+      this.taskTitleTextEl.textContent = "";
+      this.emptyStateEl.textContent = "Select an item from the sidebar to begin";
+    } else {
+      this.taskTitleEl.style.display = "block";
+      this.taskTitleTextEl.textContent = selectedItem.title;
+      this.emptyStateEl.textContent = `No terminals for "${selectedItem.title}"`;
+    }
+
+    this.renderSpawnButtons();
+    this.updateEmptyState();
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route sidebar item selection through the main panel message handler instead of a separate open/select command path
- reuse the existing singleton panel flow already used by other sidebar actions
- keep sidebar item selection consistent with the main panel selection handling

## Validation
- pnpm build
- pnpm test
- pnpm run lint (fails in the current repo because eslint is not installed in devDependencies)