### PR TITLE
Fix sidebar task selection opening task detail

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ export function activate(context: vscode.ExtensionContext) {
       await vscode.commands.executeCommand("workTerminal.openPanel");
       const panel = WorkTerminalPanel.current;
       if (panel) {
-        panel.postMessage({ type: "selectItem", itemId });
+        panel.handleSidebarMessage({ type: "itemSelected", id: itemId });
       }
     }),
   );


### PR DESCRIPTION
## Summary\n- route sidebar task selection through the existing panel itemSelected handler\n- keep the singleton Work Terminal panel reuse behavior from #123\n- restore opening the selected task detail file when clicking from the sidebar\n\n## Testing\n- pnpm test\n- pnpm build\n- pnpm run lint *(currently fails in this repo because eslint is not installed in devDependencies)*