### PR TITLE
Render empty session tab strip on panel init

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -735,6 +735,14 @@ a.wt-card-source--jira:hover {
   color: var(--vscode-tab-inactiveForeground);
 }
 
+.wt-tab-placeholder {
+  cursor: default;
+  border-bottom-color: var(--vscode-panel-border);
+  color: var(--vscode-descriptionForeground);
+  font-weight: 500;
+  pointer-events: none;
+}
+
 .wt-tab:hover {
   --wt-tab-fill: var(--vscode-tab-hoverBackground, var(--vscode-list-hoverBackground));
 }

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -177,6 +177,7 @@ export class TerminalPanel {
     this.taskTitleTextEl = document.getElementById("task-title-text")!;
 
     injectXtermCss();
+    this.renderTabBar();
     this.renderSpawnButtons();
 
     // Observe terminal wrapper resizes to refit active terminal
@@ -397,6 +398,14 @@ export class TerminalPanel {
 
   private renderTabBar(): void {
     this.tabsContainerEl.innerHTML = "";
+
+    if (this.tabs.length === 0) {
+      const placeholderEl = document.createElement("div");
+      placeholderEl.className = "wt-tab wt-tab-placeholder";
+      placeholderEl.textContent = "No sessions yet";
+      this.tabsContainerEl.appendChild(placeholderEl);
+      return;
+    }
 
     for (let i = 0; i < this.tabs.length; i++) {
       const tab = this.tabs[i];


### PR DESCRIPTION
## Summary
- render the session tab strip immediately when the panel boots
- show a non-interactive empty-state tab when no sessions exist yet
- keep the tab area visibly present even if launcher/profile buttons are unavailable

## Validation
- pnpm build
- pnpm test
- pnpm run lint *(currently fails in this repo because the lint script references eslint but eslint is not installed)*

Fixes #125