### PR TITLE
Fix clipped Work Terminal profile buttons

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -700,6 +700,7 @@ a.wt-card-source--jira:hover {
   display: flex;
   flex-wrap: wrap;
   flex: 1;
+  min-width: 0;
   overflow: hidden;
   gap: 4px;
   padding-left: 6px;


### PR DESCRIPTION
## Summary
- fix the tab-bar flex layout so the tabs container can shrink instead of pushing the profile buttons out of view
- keep the empty session tab strip added in #129 while restoring the visible profile and shell launch buttons

## Root cause
The tabs container was a flex child without `min-width: 0`, so on narrow panel widths it would refuse to shrink and the sibling button area was clipped by the tab bar overflow.

## Validation
- pnpm build
- pnpm test
- pnpm run lint *(fails because `eslint` is referenced by the repo script but is not installed in this worktree/repo)*

Fixes #128