### PR TITLE
Fix sidebar item reuse path

### DIFF
--- a/src/panels/SidebarProvider.ts
+++ b/src/panels/SidebarProvider.ts
@@ -49,7 +49,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
           this._pendingMessages = [];
           break;
         case "itemSelected":
-          this._selectItemInPanelSafely(message.id);
+          this._forwardToPanelSafely(message);
           break;
         case "createItem":
           // Forward to panel
@@ -91,12 +91,6 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
   private _forwardToPanelSafely(message: WebviewMessage): void {
     void this._forwardToPanel(message).catch((error: unknown) => {
       console.error("[work-terminal] Failed to forward sidebar message to panel", error);
-    });
-  }
-
-  private _selectItemInPanelSafely(itemId: string): void {
-    void vscode.commands.executeCommand("workTerminal.selectItem", itemId).catch((error: unknown) => {
-      console.error("[work-terminal] Failed to select sidebar item in panel", error);
     });
   }
 

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -276,7 +276,7 @@ export class WorkTerminalPanel {
 
   reveal(): void {
     if (!this._disposed) {
-      this._panel.reveal();
+      this._panel.reveal(vscode.ViewColumn.One);
     }
   }
 


### PR DESCRIPTION
## Summary
- route sidebar item clicks through the existing sidebar-to-panel forwarding path
- keep the Work Terminal panel anchored to the primary editor column when reusing it
- avoid the extra selectItem command hop that could reopen the panel on a separate path

## Validation
- pnpm test
- pnpm build
- pnpm run lint *(fails in this repo because eslint is not installed in devDependencies)*