### PR TITLE
Render configured profile button icons

### DIFF
--- a/src/webview/profileIcons.ts
+++ b/src/webview/profileIcons.ts
@@ -1,0 +1,32 @@
+import type { ProfileIcon } from "../core/agents/types";
+
+export const PROFILE_ICON_SYMBOLS: Partial<Record<ProfileIcon, string>> = {
+  terminal: "\u{1F4BB}",
+  bot: "\u{1F916}",
+  brain: "\u{1F9E0}",
+  code: "\u{1F4DD}",
+  rocket: "\u{1F680}",
+  zap: "\u26A1",
+  cog: "\u2699\uFE0F",
+  wrench: "\u{1F527}",
+  shield: "\u{1F6E1}\uFE0F",
+  globe: "\u{1F310}",
+  search: "\u{1F50D}",
+  lightbulb: "\u{1F4A1}",
+  flask: "\u{1F9EA}",
+  book: "\u{1F4D6}",
+  puzzle: "\u{1F9E9}",
+  bee: "\u{1F41D}",
+  claude: "\u2728",
+  copilot: "\u2708\uFE0F",
+  aws: "\u2601\uFE0F",
+  skyscanner: "\u2708\uFE0F",
+};
+
+export function getProfileIconSymbol(icon?: string): string {
+  if (!icon) {
+    return "";
+  }
+
+  return PROFILE_ICON_SYMBOLS[icon as ProfileIcon] || "";
+}

--- a/src/webview/profileManager.ts
+++ b/src/webview/profileManager.ts
@@ -13,6 +13,7 @@ import {
   BRAND_COLORS,
   PROFILE_ICONS,
 } from "../core/agents/types";
+import { getProfileIconSymbol } from "./profileIcons";
 
 // ---------------------------------------------------------------------------
 // Label maps
@@ -55,33 +56,6 @@ const ICON_LABELS: Partial<Record<ProfileIcon, string>> = {
   skyscanner: "Skyscanner (branded)",
 };
 
-/**
- * Map profile icons to Unicode symbols for display in the webview.
- * (Codicons are not available without loading the font.)
- */
-const ICON_SYMBOLS: Partial<Record<ProfileIcon, string>> = {
-  terminal: "\u{1F4BB}",
-  bot: "\u{1F916}",
-  brain: "\u{1F9E0}",
-  code: "\u{1F4DD}",
-  rocket: "\u{1F680}",
-  zap: "\u26A1",
-  cog: "\u2699\uFE0F",
-  wrench: "\u{1F527}",
-  shield: "\u{1F6E1}\uFE0F",
-  globe: "\u{1F310}",
-  search: "\u{1F50D}",
-  lightbulb: "\u{1F4A1}",
-  flask: "\u{1F9EA}",
-  book: "\u{1F4D6}",
-  puzzle: "\u{1F9E9}",
-  bee: "\u{1F41D}",
-  claude: "\u2728",
-  copilot: "\u2708\uFE0F",
-  aws: "\u2601\uFE0F",
-  skyscanner: "\u2708\uFE0F",
-};
-
 // ---------------------------------------------------------------------------
 // HTML builders for the webview
 // ---------------------------------------------------------------------------
@@ -122,7 +96,7 @@ export function renderProfileList(profiles: AgentProfile[]): string {
       : "";
 
     const iconDisplay = p.button.icon
-      ? `<span class="wt-profile-icon" title="${escapeHtml(ICON_LABELS[p.button.icon] || p.button.icon)}">${ICON_SYMBOLS[p.button.icon] || ""}</span>`
+      ? `<span class="wt-profile-icon" title="${escapeHtml(ICON_LABELS[p.button.icon] || p.button.icon)}">${getProfileIconSymbol(p.button.icon)}</span>`
       : "";
 
     const isFirst = index === 0;

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -849,6 +849,12 @@ a.wt-card-source--jira:hover {
   gap: 2px;
 }
 
+.wt-spawn-profile-icon {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
 .wt-spawn-custom {
   min-width: 28px;
   text-align: center;

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -13,6 +13,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import type { WebviewMessage, TerminalSessionInfo, ButtonProfileInfo, WorkItemDTO } from "./messages";
+import { getProfileIconSymbol } from "./profileIcons";
 
 // ---------------------------------------------------------------------------
 // xterm.js CSS (embedded to avoid CSP issues with external stylesheets)
@@ -84,36 +85,6 @@ function injectXtermCss(): void {
     .xterm .xterm-decoration-top { z-index: 2; position: relative; }
   `;
   document.head.appendChild(style);
-}
-
-// ---------------------------------------------------------------------------
-// Profile icon mapping (profile icon names to codicon names)
-// ---------------------------------------------------------------------------
-
-function mapProfileIcon(icon: string): string {
-  const iconMap: Record<string, string> = {
-    claude: "sparkle",
-    copilot: "copilot",
-    terminal: "terminal",
-    bot: "robot",
-    brain: "symbol-misc",
-    code: "code",
-    rocket: "rocket",
-    zap: "zap",
-    cog: "gear",
-    wrench: "wrench",
-    shield: "shield",
-    globe: "globe",
-    search: "search",
-    lightbulb: "lightbulb",
-    flask: "beaker",
-    book: "book",
-    puzzle: "extensions",
-    bee: "bug",
-    aws: "cloud",
-    skyscanner: "globe",
-  };
-  return iconMap[icon] || "terminal";
 }
 
 // ---------------------------------------------------------------------------
@@ -535,7 +506,8 @@ export class TerminalPanel {
 
       if (profile.icon) {
         const iconSpan = document.createElement("span");
-        iconSpan.className = `codicon codicon-${mapProfileIcon(profile.icon)}`;
+        iconSpan.className = "wt-spawn-profile-icon";
+        iconSpan.textContent = getProfileIconSymbol(profile.icon);
         iconSpan.style.marginRight = "4px";
         if (profile.color) iconSpan.style.color = profile.color;
         btn.appendChild(iconSpan);


### PR DESCRIPTION
## Summary
- reuse the webview's existing unicode icon symbols for terminal header profile buttons
- share the icon mapping between the profile manager overlay and terminal panel renderer
- add a small spawn-button icon style so the symbols align consistently in the header

## Validation
- pnpm test
- pnpm build
- pnpm run lint *(fails in baseline because eslint is not installed in devDependencies)*

Fixes #137