### PR TITLE
Add Agent Profiles entry to overflow menu

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -511,9 +511,19 @@ a.wt-card-source--jira:hover {
   white-space: nowrap;
 }
 
-.wt-context-menu-item:hover {
+.wt-context-menu-item:hover,
+.wt-context-menu-item:focus-visible {
   background: var(--vscode-menu-selectionBackground);
   color: var(--vscode-menu-selectionForeground);
+}
+
+.wt-context-menu-item-button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: inherit;
 }
 
 .wt-context-menu-separator {

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -733,6 +733,8 @@ export class TerminalPanel {
 
     const menu = document.createElement("div");
     menu.className = "wt-context-menu";
+    menu.setAttribute("role", "menu");
+    menu.tabIndex = -1;
     menu.style.cssText =
       "position: fixed; z-index: 1000; " +
       "background: var(--vscode-menu-background); color: var(--vscode-menu-foreground); " +
@@ -741,25 +743,48 @@ export class TerminalPanel {
       "box-shadow: 0 2px 8px rgba(0,0,0,0.3);";
 
     const menuItemStyle =
-      "padding: 4px 16px; cursor: pointer; font-size: 12px; white-space: nowrap;";
+      "display: block; width: 100%; padding: 4px 16px; cursor: pointer; font-size: 12px; " +
+      "white-space: nowrap; text-align: left; border: none; background: transparent; color: inherit;";
+
+    const dismissMenu = () => {
+      menu.remove();
+      document.removeEventListener("mousedown", dismiss);
+      document.removeEventListener("keydown", onKeyDown);
+      anchorEl.focus();
+    };
+
+    const menuItems: HTMLButtonElement[] = [];
+
+    const focusItem = (index: number) => {
+      if (menuItems.length === 0) {
+        return;
+      }
+
+      const targetIndex = (index + menuItems.length) % menuItems.length;
+      menuItems[targetIndex].focus();
+    };
 
     const addItem = (label: string, action: () => void) => {
-      const el = document.createElement("div");
+      const el = document.createElement("button");
+      el.type = "button";
+      el.setAttribute("role", "menuitem");
       el.textContent = label;
       el.style.cssText = menuItemStyle;
       el.addEventListener("mouseenter", () => {
         el.style.background = "var(--vscode-menu-selectionBackground)";
         el.style.color = "var(--vscode-menu-selectionForeground)";
+        el.focus();
       });
       el.addEventListener("mouseleave", () => {
         el.style.background = "";
         el.style.color = "";
       });
       el.addEventListener("click", () => {
-        menu.remove();
+        dismissMenu();
         action();
       });
       menu.appendChild(el);
+      menuItems.push(el);
     };
 
     addItem("Launch Profile", () => {
@@ -795,11 +820,42 @@ export class TerminalPanel {
 
     const dismiss = (e: MouseEvent) => {
       if (!menu.contains(e.target as Node) && e.target !== anchorEl) {
-        menu.remove();
-        document.removeEventListener("mousedown", dismiss);
+        dismissMenu();
       }
     };
-    requestAnimationFrame(() => { document.addEventListener("mousedown", dismiss); });
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const currentIndex = menuItems.findIndex((item) => item === document.activeElement);
+
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          dismissMenu();
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          focusItem(currentIndex + 1);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          focusItem(currentIndex - 1);
+          break;
+        case "Home":
+          e.preventDefault();
+          focusItem(0);
+          break;
+        case "End":
+          e.preventDefault();
+          focusItem(menuItems.length - 1);
+          break;
+      }
+    };
+
+    requestAnimationFrame(() => {
+      document.addEventListener("mousedown", dismiss);
+      document.addEventListener("keydown", onKeyDown);
+      focusItem(0);
+    });
   }
 
   private showTabContextMenu(index: number, x: number, y: number): void {

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -557,13 +557,10 @@ export class TerminalPanel {
     const launchBtn = document.createElement("button");
     launchBtn.className = "wt-spawn-btn wt-spawn-custom";
     launchBtn.textContent = "...";
-    launchBtn.title = "Launch profile";
-    launchBtn.setAttribute("aria-label", "Launch profile");
+    launchBtn.title = "More profile actions";
+    launchBtn.setAttribute("aria-label", "More profile actions");
     launchBtn.addEventListener("click", () => {
-      this.postMessage({
-        type: "requestLaunchModal",
-        itemId: this.selectedItemId ?? undefined,
-      });
+      this.showOverflowMenu(launchBtn);
     });
     this.tabButtonsEl.appendChild(launchBtn);
 
@@ -729,6 +726,81 @@ export class TerminalPanel {
   // -------------------------------------------------------------------------
   // Context menu
   // -------------------------------------------------------------------------
+
+  private showOverflowMenu(anchorEl: HTMLElement): void {
+    const existing = document.querySelector(".wt-context-menu");
+    if (existing) existing.remove();
+
+    const menu = document.createElement("div");
+    menu.className = "wt-context-menu";
+    menu.style.cssText =
+      "position: fixed; z-index: 1000; " +
+      "background: var(--vscode-menu-background); color: var(--vscode-menu-foreground); " +
+      "border: 1px solid var(--vscode-menu-border, var(--vscode-panel-border)); " +
+      "border-radius: 4px; padding: 4px 0; min-width: 180px; " +
+      "box-shadow: 0 2px 8px rgba(0,0,0,0.3);";
+
+    const menuItemStyle =
+      "padding: 4px 16px; cursor: pointer; font-size: 12px; white-space: nowrap;";
+
+    const addItem = (label: string, action: () => void) => {
+      const el = document.createElement("div");
+      el.textContent = label;
+      el.style.cssText = menuItemStyle;
+      el.addEventListener("mouseenter", () => {
+        el.style.background = "var(--vscode-menu-selectionBackground)";
+        el.style.color = "var(--vscode-menu-selectionForeground)";
+      });
+      el.addEventListener("mouseleave", () => {
+        el.style.background = "";
+        el.style.color = "";
+      });
+      el.addEventListener("click", () => {
+        menu.remove();
+        action();
+      });
+      menu.appendChild(el);
+    };
+
+    addItem("Launch Profile", () => {
+      this.postMessage({
+        type: "requestLaunchModal",
+        itemId: this.selectedItemId ?? undefined,
+      });
+    });
+
+    addItem("Agent Profiles", () => {
+      this.postMessage({ type: "getProfiles" });
+    });
+
+    document.body.appendChild(menu);
+
+    const anchorRect = anchorEl.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    let left = anchorRect.right - menuRect.width;
+    let top = anchorRect.bottom + 4;
+
+    if (left < 0) {
+      left = 0;
+    }
+    if (left + menuRect.width > window.innerWidth) {
+      left = Math.max(0, window.innerWidth - menuRect.width);
+    }
+    if (top + menuRect.height > window.innerHeight) {
+      top = Math.max(0, anchorRect.top - menuRect.height - 4);
+    }
+
+    menu.style.left = `${left}px`;
+    menu.style.top = `${top}px`;
+
+    const dismiss = (e: MouseEvent) => {
+      if (!menu.contains(e.target as Node) && e.target !== anchorEl) {
+        menu.remove();
+        document.removeEventListener("mousedown", dismiss);
+      }
+    };
+    requestAnimationFrame(() => { document.addEventListener("mousedown", dismiss); });
+  }
 
   private showTabContextMenu(index: number, x: number, y: number): void {
     const existing = document.querySelector(".wt-context-menu");

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -167,6 +167,7 @@ export class TerminalPanel {
   private resizeObserver: ResizeObserver;
   private tabBarResizeObserver: ResizeObserver | null = null;
   private tabBarOverflowFrame: number | null = null;
+  private dismissOverflowMenu: (() => void) | null = null;
   private searchBarVisible = false;
   private buttonProfiles: ButtonProfileInfo[] = [];
   private workItems: WorkItemDTO[] = [];
@@ -559,6 +560,8 @@ export class TerminalPanel {
     launchBtn.textContent = "...";
     launchBtn.title = "More profile actions";
     launchBtn.setAttribute("aria-label", "More profile actions");
+    launchBtn.setAttribute("aria-haspopup", "menu");
+    launchBtn.setAttribute("aria-expanded", "false");
     launchBtn.addEventListener("click", () => {
       this.showOverflowMenu(launchBtn);
     });
@@ -728,30 +731,34 @@ export class TerminalPanel {
   // -------------------------------------------------------------------------
 
   private showOverflowMenu(anchorEl: HTMLElement): void {
-    const existing = document.querySelector(".wt-context-menu");
-    if (existing) existing.remove();
+    const wasExpanded = anchorEl.getAttribute("aria-expanded") === "true";
+    this.dismissOverflowMenu?.();
+    if (wasExpanded) {
+      return;
+    }
 
     const menu = document.createElement("div");
     menu.className = "wt-context-menu";
     menu.setAttribute("role", "menu");
     menu.tabIndex = -1;
-    menu.style.cssText =
-      "position: fixed; z-index: 1000; " +
-      "background: var(--vscode-menu-background); color: var(--vscode-menu-foreground); " +
-      "border: 1px solid var(--vscode-menu-border, var(--vscode-panel-border)); " +
-      "border-radius: 4px; padding: 4px 0; min-width: 180px; " +
-      "box-shadow: 0 2px 8px rgba(0,0,0,0.3);";
-
-    const menuItemStyle =
-      "display: block; width: 100%; padding: 4px 16px; cursor: pointer; font-size: 12px; " +
-      "white-space: nowrap; text-align: left; border: none; background: transparent; color: inherit;";
+    menu.style.minWidth = "180px";
+    anchorEl.setAttribute("aria-expanded", "true");
 
     const dismissMenu = () => {
+      if (!menu.isConnected) {
+        anchorEl.setAttribute("aria-expanded", "false");
+        this.dismissOverflowMenu = null;
+        return;
+      }
+
       menu.remove();
       document.removeEventListener("mousedown", dismiss);
       document.removeEventListener("keydown", onKeyDown);
+      anchorEl.setAttribute("aria-expanded", "false");
+      this.dismissOverflowMenu = null;
       anchorEl.focus();
     };
+    this.dismissOverflowMenu = dismissMenu;
 
     const menuItems: HTMLButtonElement[] = [];
 
@@ -767,17 +774,11 @@ export class TerminalPanel {
     const addItem = (label: string, action: () => void) => {
       const el = document.createElement("button");
       el.type = "button";
+      el.className = "wt-context-menu-item wt-context-menu-item-button";
       el.setAttribute("role", "menuitem");
       el.textContent = label;
-      el.style.cssText = menuItemStyle;
       el.addEventListener("mouseenter", () => {
-        el.style.background = "var(--vscode-menu-selectionBackground)";
-        el.style.color = "var(--vscode-menu-selectionForeground)";
         el.focus();
-      });
-      el.addEventListener("mouseleave", () => {
-        el.style.background = "";
-        el.style.color = "";
       });
       el.addEventListener("click", () => {
         dismissMenu();


### PR DESCRIPTION
## Summary
- change the `...` button into a small overflow menu instead of jumping straight into launch
- keep Launch Profile as the primary action from that menu
- add a direct Agent Profiles entry that reuses the existing `getProfiles` panel flow

## Validation
- pnpm test
- pnpm build
- pnpm run lint *(fails in baseline because eslint is not installed in devDependencies)*

Fixes #138