### PR TITLE
Fix Copilot profiles defaulting to gh

### DIFF
--- a/src/agents/AgentProfileManager.test.ts
+++ b/src/agents/AgentProfileManager.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentProfile } from "../core/agents/types";
+
+const { getConfigurationMock } = vi.hoisted(() => ({
+  getConfigurationMock: vi.fn(),
+}));
+
+vi.mock("vscode", () => {
+  class EventEmitter<T> {
+    public event = vi.fn();
+    public fire = vi.fn();
+    public dispose = vi.fn();
+  }
+
+  return {
+    EventEmitter,
+    workspace: {
+      getConfiguration: getConfigurationMock,
+    },
+  };
+});
+
+import { AgentProfileManager } from "./AgentProfileManager";
+import { createDefaultProfile } from "../core/agents/types";
+
+class FakeMemento {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key) as T | undefined;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.store.set(key, value);
+  }
+}
+
+function createConfig(values: Record<string, string>) {
+  return {
+    get<T>(key: string, defaultValue?: T): T {
+      return (values[key] as T | undefined) ?? (defaultValue as T);
+    },
+  };
+}
+
+function createCopilotProfile(overrides?: Partial<AgentProfile>): AgentProfile {
+  return createDefaultProfile({
+    id: "copilot-profile",
+    name: "Copilot",
+    agentType: "copilot",
+    sortOrder: 0,
+    ...overrides,
+  });
+}
+
+describe("AgentProfileManager copilot defaults", () => {
+  beforeEach(() => {
+    getConfigurationMock.mockReset();
+  });
+
+  it("defaults copilot profiles to the copilot executable", () => {
+    const manager = new AgentProfileManager(new FakeMemento() as never);
+
+    expect(manager.resolveCommand(createCopilotProfile())).toBe("copilot");
+  });
+
+  it("migrates an explicit copilotCommand override into copilot profiles", async () => {
+    getConfigurationMock.mockReturnValue(
+      createConfig({
+        claudeCommand: "claude",
+        claudeExtraArgs: "",
+        copilotCommand: "gh",
+        copilotExtraArgs: "--model gpt-5",
+        strandsCommand: "",
+        strandsExtraArgs: "",
+      }),
+    );
+
+    const globalState = new FakeMemento();
+    await globalState.update("agentProfiles", [createCopilotProfile()]);
+
+    const manager = new AgentProfileManager(globalState as never);
+    const profiles = await manager.load();
+    const copilotProfile = profiles.find((profile) => profile.id === "copilot-profile");
+
+    expect(copilotProfile?.command).toBe("gh");
+    expect(copilotProfile?.arguments).toBe("--model gpt-5");
+  });
+});

--- a/src/agents/AgentProfileManager.ts
+++ b/src/agents/AgentProfileManager.ts
@@ -153,7 +153,7 @@ export class AgentProfileManager {
       case "claude":
         return "claude";
       case "copilot":
-        return "gh";
+        return "copilot";
       case "strands":
         return "strands";
       case "shell": {
@@ -199,7 +199,7 @@ export class AgentProfileManager {
 
     const claudeCmd = config.get<string>("claudeCommand", "claude");
     const claudeArgs = config.get<string>("claudeExtraArgs", "");
-    const copilotCmd = config.get<string>("copilotCommand", "gh");
+    const copilotCmd = config.get<string>("copilotCommand", "copilot");
     const copilotArgs = config.get<string>("copilotExtraArgs", "");
     const strandsCmd = config.get<string>("strandsCommand", "");
     const strandsArgs = config.get<string>("strandsExtraArgs", "");
@@ -207,7 +207,7 @@ export class AgentProfileManager {
     const hasClaudeOverrides =
       (claudeCmd && claudeCmd !== "claude") || (claudeArgs && claudeArgs.trim() !== "");
     const hasCopilotOverrides =
-      (copilotCmd && copilotCmd !== "gh") || (copilotArgs && copilotArgs.trim() !== "");
+      (copilotCmd && copilotCmd !== "copilot") || (copilotArgs && copilotArgs.trim() !== "");
     const hasStrandsOverrides =
       (strandsCmd && strandsCmd.trim() !== "") || (strandsArgs && strandsArgs.trim() !== "");
 
@@ -228,7 +228,7 @@ export class AgentProfileManager {
     if (hasCopilotOverrides) {
       for (const p of this.profiles) {
         if (p.agentType === "copilot") {
-          if (copilotCmd && copilotCmd !== "gh" && !p.command.trim()) {
+          if (copilotCmd && copilotCmd !== "copilot" && !p.command.trim()) {
             p.command = copilotCmd;
           }
           if (copilotArgs && copilotArgs.trim() && !p.arguments.trim()) {


### PR DESCRIPTION
## Summary
- make Copilot profiles default to the `copilot` executable instead of `gh`
- align legacy `copilotCommand` migration logic with that same default
- add a regression test covering the default and migrated override path

## Validation
- pnpm install --frozen-lockfile
- pnpm test
- pnpm build
- pnpm run lint *(fails in baseline because eslint is not installed in devDependencies)*

Fixes #135