### PR TITLE
Add node-pty rebuild repair flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ esbuild produces three bundles in `dist/`:
 
 ## Known constraints
 
-- **node-pty** - Required for real PTY terminal sessions. Native module that needs rebuild per platform/Electron version. If the Extension Development Host cannot load `pty.node`, run the `Work Terminal: Rebuild node-pty Native Module` command and reload the window.
+- **node-pty** - Required for real PTY terminal sessions. Native module that needs rebuild per platform/Electron version. If the Extension Development Host cannot load `pty.node`, run the `Work Terminal: Rebuild node-pty Native Module` command and reload the window. That repair path is only supported from a local source checkout with `pnpm` and `node_modules/node-pty` present.
 - **xterm.js CSS** - Full CSS embedded inline via the webview HTML since webviews cannot load node_modules CSS directly.
 - **Tilde expansion** - Always expand `~` via `os.homedir()` before passing paths to spawn or file operations.
 - **Webview isolation** - Webviews run in an iframe sandbox. All communication with the extension host is via `postMessage`. No shared memory, no direct DOM access from extension code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ esbuild produces three bundles in `dist/`:
 
 ## Known constraints
 
-- **node-pty** - Required for real PTY terminal sessions. Native module that needs rebuild per platform/Electron version.
+- **node-pty** - Required for real PTY terminal sessions. Native module that needs rebuild per platform/Electron version. If the Extension Development Host cannot load `pty.node`, run the `Work Terminal: Rebuild node-pty Native Module` command and reload the window.
 - **xterm.js CSS** - Full CSS embedded inline via the webview HTML since webviews cannot load node_modules CSS directly.
 - **Tilde expansion** - Always expand `~` via `os.homedir()` before passing paths to spawn or file operations.
 - **Webview isolation** - Webviews run in an iframe sandbox. All communication with the extension host is via `postMessage`. No shared memory, no direct DOM access from extension code.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ pnpm build
 
 Press **F5** in VS Code to launch an Extension Development Host with the extension loaded. The `watch` script provides incremental rebuilds during development.
 
+If the Extension Development Host reports that `node-pty` could not load `pty.node`, run **Work Terminal: Rebuild node-pty Native Module** from the command palette, then reload the window.
+
 ### Build output
 
 esbuild produces three bundles in `dist/`:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pnpm build
 
 Press **F5** in VS Code to launch an Extension Development Host with the extension loaded. The `watch` script provides incremental rebuilds during development.
 
-If the Extension Development Host reports that `node-pty` could not load `pty.node`, run **Work Terminal: Rebuild node-pty Native Module** from the command palette, then reload the window.
+If the Extension Development Host reports that `node-pty` could not load `pty.node`, run **Work Terminal: Rebuild node-pty Native Module** from the command palette, then reload the window. The repair command only works from a local source checkout with `pnpm` and `node_modules/node-pty` available. Packaged VSIX installs cannot rebuild in place.
 
 ### Build output
 

--- a/package.json
+++ b/package.json
@@ -110,6 +110,11 @@
         "category": "Work Terminal"
       },
       {
+        "command": "workTerminal.rebuildNodePty",
+        "title": "Rebuild node-pty Native Module",
+        "category": "Work Terminal"
+      },
+      {
         "command": "workTerminal.hookStatus",
         "title": "Claude Hooks: Show Status",
         "category": "Work Terminal"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,16 @@
 import * as vscode from "vscode";
-import { spawn } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { spawn, spawnSync } from "child_process";
 import { WorkTerminalPanel } from "./panels/WorkTerminalPanel";
 import { SidebarProvider } from "./panels/SidebarProvider";
 import { TaskAgentAdapter } from "./adapters/task-agent/index";
 import { checkHookStatus, installHooks, removeHooks } from "./agents/ClaudeHookManager";
-import { createNodePtyRebuildPlan } from "./terminal/nodePtySupport";
+import {
+  createNodePtyRebuildPlan,
+  formatNodePtyRebuildFailure,
+  getNodePtyRebuildUnsupportedReason,
+} from "./terminal/nodePtySupport";
 
 export function activate(context: vscode.ExtensionContext) {
   const sidebarProvider = new SidebarProvider(context.extensionUri);
@@ -229,21 +235,43 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("workTerminal.rebuildNodePty", async () => {
       const extension = vscode.extensions.getExtension("tomcorke.vscode-work-terminal-v2");
-      const canRepairLocally =
+      const isDevelopmentMode =
         extension?.extensionMode === vscode.ExtensionMode.Development
         || extension?.extensionMode === vscode.ExtensionMode.Test;
-      if (!canRepairLocally) {
-        vscode.window.showInformationMessage(
-          "node-pty rebuild is only available from a local Extension Development Host.",
-        );
-        return;
-      }
 
       let plan;
       try {
         plan = createNodePtyRebuildPlan(process.versions.electron);
       } catch (err) {
         vscode.window.showErrorMessage(err instanceof Error ? err.message : String(err));
+        return;
+      }
+
+      const nodePtyPackagePath = path.join(
+        context.extensionPath,
+        "node_modules",
+        "node-pty",
+        "package.json",
+      );
+      let unsupportedReason = getNodePtyRebuildUnsupportedReason({
+        isDevelopmentMode,
+        hasNodePtyDependency: fs.existsSync(nodePtyPackagePath),
+        pnpmAvailable: true,
+      });
+      if (!unsupportedReason) {
+        const pnpmCheck = spawnSync(plan.command, ["--version"], {
+          cwd: context.extensionPath,
+          env: process.env,
+          encoding: "utf8",
+        });
+        unsupportedReason = getNodePtyRebuildUnsupportedReason({
+          isDevelopmentMode,
+          hasNodePtyDependency: true,
+          pnpmAvailable: pnpmCheck.error == null && pnpmCheck.status === 0,
+        });
+      }
+      if (unsupportedReason) {
+        vscode.window.showErrorMessage(unsupportedReason);
         return;
       }
 
@@ -273,18 +301,13 @@ export function activate(context: vscode.ExtensionContext) {
             });
 
             child.on("error", reject);
-            child.on("exit", (code, signal) => {
+            child.on("close", (code, signal) => {
               if (code === 0) {
                 resolve();
                 return;
               }
 
-              const combinedOutput = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n\n");
-              const fallbackReason =
-                signal != null
-                  ? `node-pty rebuild failed due to signal ${signal}.`
-                  : `node-pty rebuild failed with exit code ${code ?? "unknown"}.`;
-              reject(new Error(combinedOutput || fallbackReason));
+              reject(new Error(formatNodePtyRebuildFailure(code, signal, stdout, stderr)));
             });
           }),
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -263,18 +263,28 @@ export function activate(context: vscode.ExtensionContext) {
               stdio: "pipe",
             });
 
+            let stdout = "";
             let stderr = "";
+            child.stdout?.on("data", (chunk: Buffer) => {
+              stdout += chunk.toString("utf8");
+            });
             child.stderr?.on("data", (chunk: Buffer) => {
               stderr += chunk.toString("utf8");
             });
 
             child.on("error", reject);
-            child.on("exit", (code) => {
+            child.on("exit", (code, signal) => {
               if (code === 0) {
                 resolve();
                 return;
               }
-              reject(new Error(stderr.trim() || `node-pty rebuild failed with exit code ${code}.`));
+
+              const combinedOutput = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n\n");
+              const fallbackReason =
+                signal != null
+                  ? `node-pty rebuild failed due to signal ${signal}.`
+                  : `node-pty rebuild failed with exit code ${code ?? "unknown"}.`;
+              reject(new Error(combinedOutput || fallbackReason));
             });
           }),
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode";
+import { spawn } from "child_process";
 import { WorkTerminalPanel } from "./panels/WorkTerminalPanel";
 import { SidebarProvider } from "./panels/SidebarProvider";
 import { TaskAgentAdapter } from "./adapters/task-agent/index";
 import { checkHookStatus, installHooks, removeHooks } from "./agents/ClaudeHookManager";
+import { createNodePtyRebuildPlan } from "./terminal/nodePtySupport";
 
 export function activate(context: vscode.ExtensionContext) {
   const sidebarProvider = new SidebarProvider(context.extensionUri);
@@ -222,6 +224,63 @@ export function activate(context: vscode.ExtensionContext) {
       await vscode.env.clipboard.writeText(text);
       vscode.window.showInformationMessage("Session diagnostics copied to clipboard.");
     })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("workTerminal.rebuildNodePty", async () => {
+      let plan;
+      try {
+        plan = createNodePtyRebuildPlan(process.versions.electron);
+      } catch (err) {
+        vscode.window.showErrorMessage(err instanceof Error ? err.message : String(err));
+        return;
+      }
+
+      try {
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: `Rebuilding node-pty for Electron ${process.versions.electron}`,
+          },
+          () => new Promise<void>((resolve, reject) => {
+            const child = spawn(plan.command, plan.args, {
+              cwd: context.extensionPath,
+              env: {
+                ...process.env,
+                ...plan.env,
+              },
+              stdio: "pipe",
+            });
+
+            let stderr = "";
+            child.stderr?.on("data", (chunk: Buffer) => {
+              stderr += chunk.toString("utf8");
+            });
+
+            child.on("error", reject);
+            child.on("exit", (code) => {
+              if (code === 0) {
+                resolve();
+                return;
+              }
+              reject(new Error(stderr.trim() || `node-pty rebuild failed with exit code ${code}.`));
+            });
+          }),
+        );
+
+        const action = await vscode.window.showInformationMessage(
+          "node-pty rebuilt successfully. Reload VS Code to pick up the new native module.",
+          "Reload Window",
+        );
+        if (action === "Reload Window") {
+          await vscode.commands.executeCommand("workbench.action.reloadWindow");
+        }
+      } catch (err) {
+        vscode.window.showErrorMessage(
+          `Failed to rebuild node-pty: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }),
   );
 
   // Hook management commands (work without the panel open)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,6 +228,17 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("workTerminal.rebuildNodePty", async () => {
+      const extension = vscode.extensions.getExtension("tomcorke.vscode-work-terminal-v2");
+      const canRepairLocally =
+        extension?.extensionMode === vscode.ExtensionMode.Development
+        || extension?.extensionMode === vscode.ExtensionMode.Test;
+      if (!canRepairLocally) {
+        vscode.window.showInformationMessage(
+          "node-pty rebuild is only available from a local Extension Development Host.",
+        );
+        return;
+      }
+
       let plan;
       try {
         plan = createNodePtyRebuildPlan(process.versions.electron);

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -966,14 +966,12 @@ export class WorkTerminalPanel {
   }
 
   private _handleLaunchTerminal(itemId: string, profile?: string): void {
-    this._maybeWarnAboutNodePtyFallback();
     const sessionType: SessionType = profile && isSessionType(profile) ? profile : "shell";
     const cwd = this._resolveItemCwd(itemId);
-    this._terminalManager.createTerminal({ sessionType, itemId, cwd });
+    this._createTerminal({ sessionType, itemId, cwd });
   }
 
   private _handleCreateTerminal(terminalType: string, itemId?: string): void {
-    this._maybeWarnAboutNodePtyFallback();
     const typeMap: Record<string, SessionType> = {
       shell: "shell",
       claude: "claude",
@@ -981,7 +979,7 @@ export class WorkTerminalPanel {
     };
     const sessionType = typeMap[terminalType] || "shell";
     const cwd = itemId ? this._resolveItemCwd(itemId) : undefined;
-    this._terminalManager.createTerminal({ sessionType, itemId, cwd });
+    this._createTerminal({ sessionType, itemId, cwd });
   }
 
   // ---------------------------------------------------------------------------
@@ -995,7 +993,7 @@ export class WorkTerminalPanel {
       return;
     }
     if (entry.recoveryMode === "resume" && entry.claudeSessionId) {
-      this._terminalManager.createTerminal({
+      this._createTerminal({
         sessionType: entry.sessionType,
         itemId: entry.itemId,
         label: entry.label,
@@ -1003,7 +1001,7 @@ export class WorkTerminalPanel {
         resumeSessionId: entry.claudeSessionId,
       });
     } else {
-      this._terminalManager.createTerminal({
+      this._createTerminal({
         sessionType: entry.sessionType,
         itemId: entry.itemId,
         label: entry.label,
@@ -1020,7 +1018,7 @@ export class WorkTerminalPanel {
     if (!entry) return;
 
     if (entry.recoveryMode === "resume" && entry.claudeSessionId) {
-      this._terminalManager.createTerminal({
+      this._createTerminal({
         sessionType: entry.sessionType,
         itemId: entry.itemId,
         label: entry.label,
@@ -1028,7 +1026,7 @@ export class WorkTerminalPanel {
         resumeSessionId: entry.claudeSessionId,
       });
     } else {
-      this._terminalManager.createTerminal({
+      this._createTerminal({
         sessionType: entry.sessionType,
         itemId: entry.itemId,
         label: entry.label,
@@ -1105,7 +1103,6 @@ export class WorkTerminalPanel {
     extraArgs?: string,
   ): void {
     if (!this._profileManager) return;
-    this._maybeWarnAboutNodePtyFallback();
     const profile = this._profileManager.getProfile(profileId);
     if (!profile) return;
 
@@ -1120,7 +1117,7 @@ export class WorkTerminalPanel {
     const resolvedArgs = extraArgs ?? this._profileManager.resolveArguments(profile);
     const args = resolvedArgs ? parseExtraArgs(resolvedArgs) : undefined;
 
-    this._terminalManager.createTerminal({
+    this._createTerminal({
       sessionType,
       itemId,
       command,
@@ -1129,6 +1126,13 @@ export class WorkTerminalPanel {
       args,
       contextPrompt,
     });
+  }
+
+  private _createTerminal(
+    options: Parameters<TerminalManager["createTerminal"]>[0],
+  ): void {
+    this._maybeWarnAboutNodePtyFallback();
+    this._terminalManager.createTerminal(options);
   }
 
   private _maybeWarnAboutNodePtyFallback(): void {
@@ -1142,12 +1146,19 @@ export class WorkTerminalPanel {
     }
 
     this._nodePtyWarningShown = true;
+    const extension = vscode.extensions.getExtension("tomcorke.vscode-work-terminal-v2");
+    const canRepairLocally =
+      extension?.extensionMode === vscode.ExtensionMode.Development
+      || extension?.extensionMode === vscode.ExtensionMode.Test;
+    const actions = canRepairLocally
+      ? ["Rebuild node-pty", "Copy Diagnostics"] as const
+      : ["Copy Diagnostics"] as const;
+
     void vscode.window.showWarningMessage(
       formatNodePtyLoadWarning(nativePtyStatus),
-      "Rebuild node-pty",
-      "Copy Diagnostics",
+      ...actions,
     ).then((selection) => {
-      if (selection === "Rebuild node-pty") {
+      if (selection === "Rebuild node-pty" && canRepairLocally) {
         void vscode.commands.executeCommand("workTerminal.rebuildNodePty");
       } else if (selection === "Copy Diagnostics") {
         void vscode.commands.executeCommand("workTerminal.copyDiagnostics");

--- a/src/panels/WorkTerminalPanel.ts
+++ b/src/panels/WorkTerminalPanel.ts
@@ -18,6 +18,7 @@ import { showLaunchModal, type LaunchModalResult } from "../agents/AgentLaunchMo
 import { parseExtraArgs } from "../terminal/AgentLauncher";
 import { HookBannerService } from "../agents/HookBannerService";
 import { installHooks, removeHooks, checkHookStatus } from "../agents/ClaudeHookManager";
+import { formatNodePtyLoadWarning } from "../terminal/nodePtySupport";
 
 /**
  * Singleton panel that hosts the 2-panel webview layout.
@@ -54,6 +55,7 @@ export class WorkTerminalPanel {
   /** URI of the detail editor tab opened by the extension (null if none). */
   private _detailEditorUri: vscode.Uri | null = null;
   private _renameDisposable: vscode.Disposable | null = null;
+  private _nodePtyWarningShown = false;
 
   private constructor(extensionUri: vscode.Uri) {
     this._extensionUri = extensionUri;
@@ -964,12 +966,14 @@ export class WorkTerminalPanel {
   }
 
   private _handleLaunchTerminal(itemId: string, profile?: string): void {
+    this._maybeWarnAboutNodePtyFallback();
     const sessionType: SessionType = profile && isSessionType(profile) ? profile : "shell";
     const cwd = this._resolveItemCwd(itemId);
     this._terminalManager.createTerminal({ sessionType, itemId, cwd });
   }
 
   private _handleCreateTerminal(terminalType: string, itemId?: string): void {
+    this._maybeWarnAboutNodePtyFallback();
     const typeMap: Record<string, SessionType> = {
       shell: "shell",
       claude: "claude",
@@ -1101,6 +1105,7 @@ export class WorkTerminalPanel {
     extraArgs?: string,
   ): void {
     if (!this._profileManager) return;
+    this._maybeWarnAboutNodePtyFallback();
     const profile = this._profileManager.getProfile(profileId);
     if (!profile) return;
 
@@ -1123,6 +1128,30 @@ export class WorkTerminalPanel {
       label,
       args,
       contextPrompt,
+    });
+  }
+
+  private _maybeWarnAboutNodePtyFallback(): void {
+    if (this._nodePtyWarningShown) {
+      return;
+    }
+
+    const nativePtyStatus = this._terminalManager.getNativePtyStatus();
+    if (nativePtyStatus.available || !nativePtyStatus.loadError) {
+      return;
+    }
+
+    this._nodePtyWarningShown = true;
+    void vscode.window.showWarningMessage(
+      formatNodePtyLoadWarning(nativePtyStatus),
+      "Rebuild node-pty",
+      "Copy Diagnostics",
+    ).then((selection) => {
+      if (selection === "Rebuild node-pty") {
+        void vscode.commands.executeCommand("workTerminal.rebuildNodePty");
+      } else if (selection === "Copy Diagnostics") {
+        void vscode.commands.executeCommand("workTerminal.copyDiagnostics");
+      }
     });
   }
 
@@ -1305,9 +1334,19 @@ export class WorkTerminalPanel {
     const lines: string[] = [];
     const ext = vscode.extensions.getExtension("tomcorke.vscode-work-terminal-v2");
     const version = ext?.packageJSON?.version ?? "unknown";
+    const nativePtyStatus = this._terminalManager.getNativePtyStatus();
     lines.push(`# Work Terminal Diagnostics`);
     lines.push(`Version: ${version}`);
     lines.push(`Timestamp: ${new Date().toISOString()}`);
+    lines.push("");
+
+    lines.push("## Native PTY");
+    lines.push(`Available: ${nativePtyStatus.available ? "yes" : "no"}`);
+    lines.push(`Electron: ${nativePtyStatus.electronVersion ?? "unknown"}`);
+    lines.push(`Module path: ${nativePtyStatus.modulePath ?? "unresolved"}`);
+    if (nativePtyStatus.loadError) {
+      lines.push(`Load error: ${nativePtyStatus.loadError}`);
+    }
     lines.push("");
 
     // Active sessions
@@ -1375,6 +1414,10 @@ export class WorkTerminalPanel {
     // Diagnostics / problem detection
     lines.push("## Derived Diagnostics");
     const problems: string[] = [];
+
+    if (!nativePtyStatus.available && nativePtyStatus.loadError) {
+      problems.push(`node-pty native binding unavailable: ${nativePtyStatus.loadError}`);
+    }
 
     // Sessions with no item attached
     const unattached = allSessions.filter((s) => !s.itemId);

--- a/src/terminal/TerminalManager.ts
+++ b/src/terminal/TerminalManager.ts
@@ -14,6 +14,7 @@ import { AgentStateDetector, aggregateState } from "./AgentStateDetector";
 import type { AgentState } from "./AgentStateDetector";
 import { AgentSessionRename } from "../agents/AgentSessionRename";
 import { buildAgentLaunchArgs, buildClaudeArgs, buildCopilotArgs, generateSessionId, augmentPath } from "./AgentLauncher";
+import type { NativePtyStatus } from "./nodePtySupport";
 
 // ---------------------------------------------------------------------------
 // node-pty types (optional dependency)
@@ -49,11 +50,16 @@ interface NodePtyModule {
 // ---------------------------------------------------------------------------
 
 let nodePty: NodePtyModule | null = null;
+let nodePtyModulePath: string | null = null;
+let nodePtyLoadError: string | null = null;
 try {
   // node-pty is an optional native dependency - fall back gracefully
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  nodePty = require("node-pty") as NodePtyModule;
-} catch {
+  nodePtyModulePath = require.resolve("node-pty");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  nodePty = require(nodePtyModulePath) as NodePtyModule;
+} catch (err) {
+  nodePtyLoadError = err instanceof Error ? err.message : String(err);
   // Will use child_process fallback
 }
 
@@ -485,6 +491,15 @@ export class TerminalManager {
       });
     }
     return result;
+  }
+
+  getNativePtyStatus(): NativePtyStatus {
+    return {
+      available: nodePty !== null,
+      modulePath: nodePtyModulePath,
+      loadError: nodePtyLoadError,
+      electronVersion: process.versions.electron ?? null,
+    };
   }
 
   /**

--- a/src/terminal/nodePtySupport.test.ts
+++ b/src/terminal/nodePtySupport.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   createNodePtyRebuildPlan,
+  formatNodePtyRebuildFailure,
   formatNodePtyLoadWarning,
+  getNodePtyRebuildUnsupportedReason,
   type NativePtyStatus,
 } from "./nodePtySupport";
 
@@ -36,5 +38,63 @@ describe("formatNodePtyLoadWarning", () => {
     const message = formatNodePtyLoadWarning(status);
     expect(message).toContain("VS Code Electron 35.1.0");
     expect(message).toContain("Cannot find module ../build/Debug/pty.node");
+  });
+});
+
+describe("getNodePtyRebuildUnsupportedReason", () => {
+  it("explains packaged installs are unsupported", () => {
+    expect(
+      getNodePtyRebuildUnsupportedReason({
+        isDevelopmentMode: false,
+        hasNodePtyDependency: true,
+        pnpmAvailable: true,
+      }),
+    ).toContain("Packaged installs");
+  });
+
+  it("requires node-pty to be installed locally", () => {
+    expect(
+      getNodePtyRebuildUnsupportedReason({
+        isDevelopmentMode: true,
+        hasNodePtyDependency: false,
+        pnpmAvailable: true,
+      }),
+    ).toContain("node_modules/node-pty");
+  });
+
+  it("requires pnpm on PATH", () => {
+    expect(
+      getNodePtyRebuildUnsupportedReason({
+        isDevelopmentMode: true,
+        hasNodePtyDependency: true,
+        pnpmAvailable: false,
+      }),
+    ).toContain("pnpm is not available");
+  });
+
+  it("allows supported local development checkouts", () => {
+    expect(
+      getNodePtyRebuildUnsupportedReason({
+        isDevelopmentMode: true,
+        hasNodePtyDependency: true,
+        pnpmAvailable: true,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("formatNodePtyRebuildFailure", () => {
+  it("includes the failure reason plus both stderr and stdout", () => {
+    const message = formatNodePtyRebuildFailure(1, null, "stdout detail", "stderr detail");
+
+    expect(message).toContain("exit code 1");
+    expect(message).toContain("stderr:\nstderr detail");
+    expect(message).toContain("stdout:\nstdout detail");
+  });
+
+  it("reports signal-based termination clearly", () => {
+    const message = formatNodePtyRebuildFailure(null, "SIGTERM", "", "");
+
+    expect(message).toBe("node-pty rebuild failed due to signal SIGTERM.");
   });
 });

--- a/src/terminal/nodePtySupport.test.ts
+++ b/src/terminal/nodePtySupport.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  createNodePtyRebuildPlan,
+  formatNodePtyLoadWarning,
+  type NativePtyStatus,
+} from "./nodePtySupport";
+
+describe("createNodePtyRebuildPlan", () => {
+  it("builds a pnpm rebuild plan targeting VS Code Electron", () => {
+    const plan = createNodePtyRebuildPlan("35.1.0");
+
+    expect(plan.args).toEqual(["rebuild", "node-pty"]);
+    expect(plan.env).toEqual({
+      npm_config_runtime: "electron",
+      npm_config_target: "35.1.0",
+      npm_config_disturl: "https://electronjs.org/headers",
+    });
+  });
+
+  it("fails clearly when Electron is unavailable", () => {
+    expect(() => createNodePtyRebuildPlan("")).toThrow(
+      "VS Code Electron version is unavailable in this process.",
+    );
+  });
+});
+
+describe("formatNodePtyLoadWarning", () => {
+  it("includes the Electron version and load error", () => {
+    const status: NativePtyStatus = {
+      available: false,
+      modulePath: null,
+      electronVersion: "35.1.0",
+      loadError: "Cannot find module ../build/Debug/pty.node",
+    };
+
+    const message = formatNodePtyLoadWarning(status);
+    expect(message).toContain("VS Code Electron 35.1.0");
+    expect(message).toContain("Cannot find module ../build/Debug/pty.node");
+  });
+});

--- a/src/terminal/nodePtySupport.ts
+++ b/src/terminal/nodePtySupport.ts
@@ -1,0 +1,38 @@
+export interface NativePtyStatus {
+  available: boolean;
+  modulePath: string | null;
+  loadError: string | null;
+  electronVersion: string | null;
+}
+
+export interface NodePtyRebuildPlan {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+const ELECTRON_HEADERS_URL = "https://electronjs.org/headers";
+
+export function createNodePtyRebuildPlan(electronVersion?: string | null): NodePtyRebuildPlan {
+  if (!electronVersion) {
+    throw new Error("VS Code Electron version is unavailable in this process.");
+  }
+
+  return {
+    command: process.platform === "win32" ? "pnpm.cmd" : "pnpm",
+    args: ["rebuild", "node-pty"],
+    env: {
+      npm_config_runtime: "electron",
+      npm_config_target: electronVersion,
+      npm_config_disturl: ELECTRON_HEADERS_URL,
+    },
+  };
+}
+
+export function formatNodePtyLoadWarning(status: NativePtyStatus): string {
+  const electronSuffix = status.electronVersion
+    ? ` for VS Code Electron ${status.electronVersion}`
+    : "";
+  const detail = status.loadError ? ` (${status.loadError})` : "";
+  return `node-pty could not load its native binding${electronSuffix}${detail}. Work Terminal will fall back to basic child_process sessions until you rebuild node-pty.`;
+}

--- a/src/terminal/nodePtySupport.ts
+++ b/src/terminal/nodePtySupport.ts
@@ -11,6 +11,12 @@ export interface NodePtyRebuildPlan {
   env: Record<string, string>;
 }
 
+export interface NodePtyRebuildPreflight {
+  isDevelopmentMode: boolean;
+  hasNodePtyDependency: boolean;
+  pnpmAvailable: boolean;
+}
+
 const ELECTRON_HEADERS_URL = "https://electronjs.org/headers";
 
 export function createNodePtyRebuildPlan(electronVersion?: string | null): NodePtyRebuildPlan {
@@ -35,4 +41,42 @@ export function formatNodePtyLoadWarning(status: NativePtyStatus): string {
     : "";
   const detail = status.loadError ? ` (${status.loadError})` : "";
   return `node-pty could not load its native binding${electronSuffix}${detail}. Work Terminal will fall back to basic child_process sessions until you rebuild node-pty.`;
+}
+
+export function getNodePtyRebuildUnsupportedReason(
+  preflight: NodePtyRebuildPreflight,
+): string | null {
+  if (!preflight.isDevelopmentMode) {
+    return "node-pty rebuild is only supported from a local Extension Development Host. Packaged installs do not expose a writable pnpm-managed dependency tree.";
+  }
+
+  if (!preflight.hasNodePtyDependency) {
+    return "node-pty rebuild requires a source checkout with node_modules/node-pty installed. Run pnpm install in the repository checkout first.";
+  }
+
+  if (!preflight.pnpmAvailable) {
+    return "pnpm is not available on PATH. Install pnpm in your development environment, then rerun the rebuild command.";
+  }
+
+  return null;
+}
+
+export function formatNodePtyRebuildFailure(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stdout: string,
+  stderr: string,
+): string {
+  const reason =
+    signal != null
+      ? `node-pty rebuild failed due to signal ${signal}.`
+      : `node-pty rebuild failed with exit code ${code ?? "unknown"}.`;
+  const stdoutTrimmed = stdout.trim();
+  const stderrTrimmed = stderr.trim();
+  const sections = [
+    stderrTrimmed ? `stderr:\n${stderrTrimmed}` : null,
+    stdoutTrimmed ? `stdout:\n${stdoutTrimmed}` : null,
+  ].filter(Boolean);
+
+  return [reason, ...sections].join("\n\n");
 }


### PR DESCRIPTION
## Summary
- expose native node-pty status in diagnostics and warn when the binding cannot load
- add a Work Terminal command to rebuild `node-pty` for the current VS Code Electron runtime
- document the repair flow for Extension Development Host sessions

## Validation
- pnpm install --frozen-lockfile
- pnpm test
- pnpm build

Fixes #145