### PR TITLE
Fix overflow menu cleanup on webview disposal

### DIFF
--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -716,14 +716,30 @@ export class TerminalPanel {
     menu.tabIndex = -1;
     menu.style.minWidth = "180px";
     anchorEl.setAttribute("aria-expanded", "true");
+    let menuDismissed = false;
+    let documentListenersAttached = false;
+
+    const detachDocumentListeners = () => {
+      if (!documentListenersAttached) {
+        return;
+      }
+
+      document.removeEventListener("mousedown", dismiss);
+      document.removeEventListener("keydown", onKeyDown);
+      documentListenersAttached = false;
+    };
 
     const dismissMenu = () => {
+      if (menuDismissed) {
+        return;
+      }
+
+      menuDismissed = true;
       if (this.overflowMenuFrame !== null) {
         cancelAnimationFrame(this.overflowMenuFrame);
         this.overflowMenuFrame = null;
       }
-      document.removeEventListener("mousedown", dismiss);
-      document.removeEventListener("keydown", onKeyDown);
+      detachDocumentListeners();
       anchorEl.setAttribute("aria-expanded", "false");
       this.dismissOverflowMenu = null;
       if (menu.isConnected) {
@@ -829,11 +845,12 @@ export class TerminalPanel {
 
     this.overflowMenuFrame = requestAnimationFrame(() => {
       this.overflowMenuFrame = null;
-      if (this.dismissOverflowMenu !== dismissMenu || this.disposed || !menu.isConnected) {
+      if (menuDismissed || this.dismissOverflowMenu !== dismissMenu || this.disposed || !menu.isConnected) {
         return;
       }
       document.addEventListener("mousedown", dismiss);
       document.addEventListener("keydown", onKeyDown);
+      documentListenersAttached = true;
       focusItem(0);
     });
   }

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -735,10 +735,7 @@ export class TerminalPanel {
       }
 
       menuDismissed = true;
-      if (this.overflowMenuFrame !== null) {
-        cancelAnimationFrame(this.overflowMenuFrame);
-        this.overflowMenuFrame = null;
-      }
+      this.cancelPendingOverflowMenuFrame();
       detachDocumentListeners();
       anchorEl.setAttribute("aria-expanded", "false");
       this.dismissOverflowMenu = null;
@@ -1329,6 +1326,12 @@ export class TerminalPanel {
     this.pendingTabSwitchFrame = null;
   }
 
+  private cancelPendingOverflowMenuFrame(): void {
+    if (this.overflowMenuFrame === null) return;
+    cancelAnimationFrame(this.overflowMenuFrame);
+    this.overflowMenuFrame = null;
+  }
+
   private isLiveTab(tab: TerminalTab): boolean {
     return !this.disposed && this.tabs.includes(tab);
   }
@@ -1345,7 +1348,10 @@ export class TerminalPanel {
 
   dispose(): void {
     this.disposed = true;
-    this.dismissOverflowMenu?.();
+    const dismissOverflowMenu = this.dismissOverflowMenu;
+    this.dismissOverflowMenu = null;
+    this.cancelPendingOverflowMenuFrame();
+    dismissOverflowMenu?.();
     this.cancelPendingTabSwitchFrame();
     this.resizeObserver.disconnect();
     this.tabBarResizeObserver?.disconnect();

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -138,6 +138,7 @@ export class TerminalPanel {
   private resizeObserver: ResizeObserver;
   private tabBarResizeObserver: ResizeObserver | null = null;
   private tabBarOverflowFrame: number | null = null;
+  private overflowMenuFrame: number | null = null;
   private dismissOverflowMenu: (() => void) | null = null;
   private searchBarVisible = false;
   private buttonProfiles: ButtonProfileInfo[] = [];
@@ -717,6 +718,10 @@ export class TerminalPanel {
     anchorEl.setAttribute("aria-expanded", "true");
 
     const dismissMenu = () => {
+      if (this.overflowMenuFrame !== null) {
+        cancelAnimationFrame(this.overflowMenuFrame);
+        this.overflowMenuFrame = null;
+      }
       document.removeEventListener("mousedown", dismiss);
       document.removeEventListener("keydown", onKeyDown);
       anchorEl.setAttribute("aria-expanded", "false");
@@ -822,7 +827,11 @@ export class TerminalPanel {
       }
     };
 
-    requestAnimationFrame(() => {
+    this.overflowMenuFrame = requestAnimationFrame(() => {
+      this.overflowMenuFrame = null;
+      if (this.dismissOverflowMenu !== dismissMenu || this.disposed || !menu.isConnected) {
+        return;
+      }
       document.addEventListener("mousedown", dismiss);
       document.addEventListener("keydown", onKeyDown);
       focusItem(0);

--- a/src/webview/terminalPanel.ts
+++ b/src/webview/terminalPanel.ts
@@ -717,18 +717,16 @@ export class TerminalPanel {
     anchorEl.setAttribute("aria-expanded", "true");
 
     const dismissMenu = () => {
-      if (!menu.isConnected) {
-        anchorEl.setAttribute("aria-expanded", "false");
-        this.dismissOverflowMenu = null;
-        return;
-      }
-
-      menu.remove();
       document.removeEventListener("mousedown", dismiss);
       document.removeEventListener("keydown", onKeyDown);
       anchorEl.setAttribute("aria-expanded", "false");
       this.dismissOverflowMenu = null;
-      anchorEl.focus();
+      if (menu.isConnected) {
+        menu.remove();
+      }
+      if (!this.disposed && anchorEl.isConnected) {
+        anchorEl.focus();
+      }
     };
     this.dismissOverflowMenu = dismissMenu;
 
@@ -832,6 +830,7 @@ export class TerminalPanel {
   }
 
   private showTabContextMenu(index: number, x: number, y: number): void {
+    this.dismissOverflowMenu?.();
     const existing = document.querySelector(".wt-context-menu");
     if (existing) existing.remove();
 
@@ -1320,6 +1319,7 @@ export class TerminalPanel {
 
   dispose(): void {
     this.disposed = true;
+    this.dismissOverflowMenu?.();
     this.cancelPendingTabSwitchFrame();
     this.resizeObserver.disconnect();
     this.tabBarResizeObserver?.disconnect();


### PR DESCRIPTION
## Summary
- route tab-context-menu opening through the overflow-menu dismiss path
- always unregister overflow-menu document listeners even if the menu node was already removed
- close the overflow menu explicitly during terminal panel disposal

## Validation
- pnpm install --frozen-lockfile
- pnpm test
- pnpm build

Fixes #146